### PR TITLE
WIP: add support for userspace-only tracing

### DIFF
--- a/include/qemu/log.h
+++ b/include/qemu/log.h
@@ -43,6 +43,11 @@ static inline bool qemu_log_enabled(void)
 #define CPU_LOG_MMU        (1 << 12)
 #define CPU_LOG_INSTR      (1 << 13)
 #define CPU_LOG_CVTRACE    (1 << 14)
+/*
+ * The CPU_LOG_USER_ONLY flag only exists so that temporarily suspending the
+ * instruction tracing does not cause QEMU to close and reopen the logfile.
+ */
+#define CPU_LOG_USER_ONLY  (1 << 15)
 
 /* Returns true if a bit is set in the current loglevel mask
  */

--- a/include/qemu/log.h
+++ b/include/qemu/log.h
@@ -43,7 +43,6 @@ static inline bool qemu_log_enabled(void)
 #define CPU_LOG_MMU        (1 << 12)
 #define CPU_LOG_INSTR      (1 << 13)
 #define CPU_LOG_CVTRACE    (1 << 14)
-#define CPU_LOG_INSTR_USER_MODE_ONLY    (1 << 15)
 
 /* Returns true if a bit is set in the current loglevel mask
  */

--- a/include/qemu/log.h
+++ b/include/qemu/log.h
@@ -43,6 +43,7 @@ static inline bool qemu_log_enabled(void)
 #define CPU_LOG_MMU        (1 << 12)
 #define CPU_LOG_INSTR      (1 << 13)
 #define CPU_LOG_CVTRACE    (1 << 14)
+#define CPU_LOG_INSTR_USER_MODE_ONLY    (1 << 15)
 
 /* Returns true if a bit is set in the current loglevel mask
  */

--- a/qemu-log.c
+++ b/qemu-log.c
@@ -106,6 +106,8 @@ const QEMULogItem qemu_log_items[] = {
       "show trace before each executed TB (lots of logs)" },
     { CPU_LOG_INSTR, "instr",
       "CHERI only: show executed instructions and changed CPU state" },
+    { CPU_LOG_INSTR | CPU_LOG_INSTR_USER_MODE_ONLY, "instr-user-mode",
+      "CHERI only: Like log instr but only logs user-mode instructions" },
     { CPU_LOG_CVTRACE, "cvtrace",
       "CHERI only: write CheriVis trace (can't be used with others)" },
     { CPU_LOG_TB_CPU, "cpu",

--- a/qemu-log.c
+++ b/qemu-log.c
@@ -106,8 +106,6 @@ const QEMULogItem qemu_log_items[] = {
       "show trace before each executed TB (lots of logs)" },
     { CPU_LOG_INSTR, "instr",
       "CHERI only: show executed instructions and changed CPU state" },
-    { CPU_LOG_INSTR | CPU_LOG_INSTR_USER_MODE_ONLY, "instr-user-mode",
-      "CHERI only: Like log instr but only logs user-mode instructions" },
     { CPU_LOG_CVTRACE, "cvtrace",
       "CHERI only: write CheriVis trace (can't be used with others)" },
     { CPU_LOG_TB_CPU, "cpu",

--- a/target-mips/cpu.h
+++ b/target-mips/cpu.h
@@ -801,9 +801,8 @@ struct CPUMIPSState {
     const char *last_mode;
 #define IN_USERSPACE(env) \
     ((env)->last_mode && strcmp((env)->last_mode, TRACE_MODE_USER) == 0)
-    int trace_level_before_suspend;
     bool user_only_tracing_enabled;
-    // bool trace_explicitly_disabled;
+    bool trace_explicitly_disabled;
     bool tracing_suspended;
 #endif /* TARGET_CHERI */
 };

--- a/target-mips/cpu.h
+++ b/target-mips/cpu.h
@@ -793,13 +793,17 @@ struct CPUMIPSState {
      */
     target_ulong last_gpr[32];
     target_ulong last_cop0[32*8];
-#define TRACE_MODE_USER "User mode"
-    const char *last_mode;
     cap_register_t last_C[32];
 
     cvtrace_t cvtrace;
-    int previous_instr_log_level;
-    bool trace_explicitly_disabled;
+
+#define TRACE_MODE_USER "User mode"
+    const char *last_mode;
+#define IN_USERSPACE(env) \
+    ((env)->last_mode && strcmp((env)->last_mode, TRACE_MODE_USER) == 0)
+    int trace_level_before_suspend;
+    bool user_only_tracing_enabled;
+    // bool trace_explicitly_disabled;
     bool tracing_suspended;
 #endif /* TARGET_CHERI */
 };

--- a/target-mips/cpu.h
+++ b/target-mips/cpu.h
@@ -793,10 +793,14 @@ struct CPUMIPSState {
      */
     target_ulong last_gpr[32];
     target_ulong last_cop0[32*8];
+#define TRACE_MODE_USER "User mode"
     const char *last_mode;
     cap_register_t last_C[32];
 
     cvtrace_t cvtrace;
+    int previous_instr_log_level;
+    bool trace_explicitly_disabled;
+    bool tracing_suspended;
 #endif /* TARGET_CHERI */
 };
 

--- a/target-mips/helper.c
+++ b/target-mips/helper.c
@@ -563,9 +563,8 @@ void mips_cpu_do_interrupt(CPUState *cs)
                  __func__, env->active_tc.PC, env->CP0_EPC, name);
     }
 #ifdef TARGET_CHERI
-    if (unlikely(qemu_loglevel_mask(CPU_LOG_INSTR) |
-                qemu_loglevel_mask(CPU_LOG_CVTRACE) |
-                qemu_loglevel_mask(CPU_LOG_INSTR_USER_MODE_ONLY))) {
+    if (unlikely(qemu_loglevel_mask(CPU_LOG_INSTR | CPU_LOG_CVTRACE)
+        || env->user_only_tracing_enabled)) {
         mips_dump_changed_state(env);
     }
 #endif /* TARGET_CHERI */

--- a/target-mips/helper.c
+++ b/target-mips/helper.c
@@ -564,8 +564,10 @@ void mips_cpu_do_interrupt(CPUState *cs)
     }
 #ifdef TARGET_CHERI
     if (unlikely(qemu_loglevel_mask(CPU_LOG_INSTR) |
-                qemu_loglevel_mask(CPU_LOG_CVTRACE)))
+                qemu_loglevel_mask(CPU_LOG_CVTRACE) |
+                qemu_loglevel_mask(CPU_LOG_INSTR_USER_MODE_ONLY))) {
         mips_dump_changed_state(env);
+    }
 #endif /* TARGET_CHERI */
     if (cs->exception_index == EXCP_EXT_INTERRUPT &&
         (env->hflags & MIPS_HFLAG_DM)) {

--- a/target-mips/helper.h
+++ b/target-mips/helper.h
@@ -229,6 +229,8 @@ DEF_HELPER_5(csc_addr, tl, env, i32, i32, tl, i32)
 DEF_HELPER_3(cscc_addr, tl, env, i32, i32)
 
 DEF_HELPER_1(instr_start, void, env)
+DEF_HELPER_1(instr_start_user_mode_only, void, env)
+DEF_HELPER_1(instr_stop_user_mode_only, void, env)
 DEF_HELPER_1(instr_stop, void, env)
 
 #ifdef CHERI_128

--- a/target-mips/helper.h
+++ b/target-mips/helper.h
@@ -228,10 +228,10 @@ DEF_HELPER_3(cllc_addr, tl, env, i32, i32)
 DEF_HELPER_5(csc_addr, tl, env, i32, i32, tl, i32)
 DEF_HELPER_3(cscc_addr, tl, env, i32, i32)
 
-DEF_HELPER_1(instr_start, void, env)
-DEF_HELPER_1(instr_start_user_mode_only, void, env)
-DEF_HELPER_1(instr_stop_user_mode_only, void, env)
-DEF_HELPER_1(instr_stop, void, env)
+DEF_HELPER_2(instr_start, void, env, i64)
+DEF_HELPER_2(instr_start_user_mode_only, void, env, i64)
+DEF_HELPER_2(instr_stop_user_mode_only, void, env, i64)
+DEF_HELPER_2(instr_stop, void, env, i64)
 
 #ifdef CHERI_128
 DEF_HELPER_5(bytes2cap_128, void, env, i32, tl, tl, tl)

--- a/target-mips/helper.h
+++ b/target-mips/helper.h
@@ -232,6 +232,7 @@ DEF_HELPER_2(instr_start, void, env, i64)
 DEF_HELPER_2(instr_start_user_mode_only, void, env, i64)
 DEF_HELPER_2(instr_stop_user_mode_only, void, env, i64)
 DEF_HELPER_2(instr_stop, void, env, i64)
+DEF_HELPER_2(cheri_debug_message, void, env, i64)
 
 #ifdef CHERI_128
 DEF_HELPER_5(bytes2cap_128, void, env, i32, tl, tl, tl)

--- a/target-mips/op_helper.c
+++ b/target-mips/op_helper.c
@@ -5537,9 +5537,7 @@ void mips_dump_changed_state(CPUMIPSState *env)
     if (new_mode != env->last_mode) {
         update_tracing_on_mode_change(env, new_mode);
         env->last_mode = new_mode;
-        if (qemu_loglevel_mask(CPU_LOG_INSTR)) {
-            fprintf(qemu_logfile, "--- %s\n", new_mode);
-        }
+        qemu_log_mask(CPU_LOG_INSTR, "--- %s\n", new_mode);
     }
 
     if (qemu_loglevel_mask(CPU_LOG_INSTR | CPU_LOG_CVTRACE)) {

--- a/target-mips/op_helper.c
+++ b/target-mips/op_helper.c
@@ -3529,9 +3529,6 @@ extern int cl_default_trace_format;
 void helper_instr_start(CPUMIPSState *env)
 {
     qemu_set_log(qemu_loglevel | cl_default_trace_format);
-    env->previous_instr_log_level = qemu_loglevel & cl_default_trace_format;
-    env->trace_explicitly_disabled = false;
-    env->tracing_suspended = false;
     uint8_t ASID = env->CP0_EntryHi & 0xFF;
     qemu_log_mask(CPU_LOG_INSTR, "--- Switching on tracing @ 0x%llx ASID %d\n",
         (unsigned long long)env->active_tc.PC, ASID);
@@ -3540,7 +3537,7 @@ void helper_instr_start(CPUMIPSState *env)
         qemu_log_mask(CPU_LOG_INSTR, "--- Delaying tracing request at 0x%llx "
             "until next switch to user mode, ASID %d\n",
             (unsigned long long)env->active_tc.PC, ASID);
-        env->trace_level_before_suspend = qemu_loglevel & (CPU_LOG_CVTRACE | CPU_LOG_INSTR);
+        env->trace_level_before_suspend = qemu_loglevel & cl_default_trace_format;
         qemu_set_log(qemu_loglevel & ~cl_default_trace_format);
         env->tracing_suspended = true;
     } else {
@@ -3551,13 +3548,10 @@ void helper_instr_start(CPUMIPSState *env)
 /* Stop instruction trace logging. */
 void helper_instr_stop(CPUMIPSState *env)
 {
-    qemu_set_log(qemu_loglevel & ~cl_default_trace_format);
-    env->previous_instr_log_level = qemu_loglevel & cl_default_trace_format;
-    env->trace_explicitly_disabled = true;
-    env->tracing_suspended = false; /* don't turn it on on next kernel -> user mode switch */
     uint8_t ASID = env->CP0_EntryHi & 0xFF;
-    qemu_log_mask(CPU_LOG_INSTR | CPU_LOG_INSTR_USER_MODE_ONLY,
-        "--- Switching off tracing @ 0x%llx ASID %d\n", (unsigned long long)env->active_tc.PC, ASID);
+    qemu_log_mask(CPU_LOG_INSTR, "--- Switching off tracing @ 0x%llx ASID %d\n",
+        (unsigned long long)env->active_tc.PC, ASID);
+    qemu_set_log(qemu_loglevel & ~cl_default_trace_format);
     /* Make sure a kernel -> user switch does not turn on tracing */
     env->trace_level_before_suspend = 0;
     env->tracing_suspended = false;
@@ -3566,18 +3560,19 @@ void helper_instr_stop(CPUMIPSState *env)
 /* Set instruction trace logging to user mode only. */
 void helper_instr_start_user_mode_only(CPUMIPSState *env)
 {
-    /* store the log level again in case it was changed using the monitor */
-    env->trace_level_before_suspend = qemu_loglevel & (CPU_LOG_CVTRACE | CPU_LOG_INSTR);
-    /* Also disable tracing if we are not currently in user mode */
-    /* XXXAR: should probably have a bool field in env instead of using strcmp */
-    if (env->last_mode && strcmp(env->last_mode, TRACE_MODE_USER) != 0) {
-        qemu_set_log(qemu_loglevel & ~(CPU_LOG_CVTRACE | CPU_LOG_INSTR));
-        env->tracing_suspended = true;
-    }
-    env->user_only_tracing_enabled = true;
     uint8_t ASID = env->CP0_EntryHi & 0xFF;
     qemu_log_mask(CPU_LOG_INSTR, "--- User-mode only tracing enabled at 0x%llx, ASID %d\n",
         (unsigned long long)env->active_tc.PC, ASID);
+
+    env->user_only_tracing_enabled = true;
+    /* Disable tracing if we are not currently in user mode */
+    if (!IN_USERSPACE(env)) {
+        env->trace_level_before_suspend = qemu_loglevel & CHERI_DEFAULT_TRACE_FLAG;
+        qemu_set_log(qemu_loglevel & ~CHERI_DEFAULT_TRACE_FLAG);
+        env->tracing_suspended = true;
+    } else {
+        env->tracing_suspended = false;
+    }
 }
 
 /* Stop instruction trace logging to user mode only. */
@@ -5511,9 +5506,9 @@ static void update_tracing_on_mode_change(CPUMIPSState *env, const char* new_mod
         /* When changing from user mode to kernel mode disable tracing */
         qemu_log_mask(CPU_LOG_INSTR, "--- Switching off tracing %s -> %s: 0x%llx ASID %d\n",
             env->last_mode, new_mode, (unsigned long long)env->active_tc.PC, ASID);
-        env->trace_level_before_suspend = qemu_loglevel & (CPU_LOG_CVTRACE | CPU_LOG_INSTR);
+        env->trace_level_before_suspend = qemu_loglevel & CHERI_DEFAULT_TRACE_FLAG;
         env->tracing_suspended = true;
-        qemu_set_log(qemu_loglevel & ~(CPU_LOG_CVTRACE | CPU_LOG_INSTR));
+        qemu_set_log(qemu_loglevel & ~CHERI_DEFAULT_TRACE_FLAG);
     } else if (strcmp(new_mode, TRACE_MODE_USER) == 0) {
         /* When changing back to user mode restore instruction tracing */
         assert(!IN_USERSPACE(env));
@@ -5541,7 +5536,7 @@ void mips_dump_changed_state(CPUMIPSState *env)
         }
     }
 
-    if (qemu_loglevel_mask(CPU_LOG_INSTR) || qemu_loglevel_mask(CPU_LOG_CVTRACE)) {
+    if (qemu_loglevel_mask(CPU_LOG_INSTR | CPU_LOG_CVTRACE)) {
         /* Print changed state: GPR, Cap. */
         dump_changed_regs(env);
     }

--- a/target-mips/op_helper.c
+++ b/target-mips/op_helper.c
@@ -3536,18 +3536,18 @@ extern int cl_default_trace_format;
 /* Start instruction trace logging. */
 void helper_instr_start(CPUMIPSState *env)
 {
-    qemu_set_log(qemu_loglevel | cl_default_trace_format);
-    user_trace_dbg("Switching on tracing @ 0x%lx ASID %lu\n",
-        env->active_tc.PC, env->CP0_EntryHi & 0xFF);
     /* Don't turn on tracing if user-mode only is selected and we are in the kernel */
     if (env->user_only_tracing_enabled && !IN_USERSPACE(env)) {
+        assert(qemu_loglevel_mask(CPU_LOG_USER_ONLY));
         user_trace_dbg("Delaying tracing request at 0x%lx "
             "until next switch to user mode, ASID %lu\n",
             env->active_tc.PC, env->CP0_EntryHi & 0xFF);
-        env->trace_level_before_suspend = qemu_loglevel & cl_default_trace_format;
-        qemu_set_log(qemu_loglevel & ~cl_default_trace_format);
+        env->trace_level_before_suspend = cl_default_trace_format;
         env->tracing_suspended = true;
     } else {
+        qemu_set_log(qemu_loglevel | cl_default_trace_format);
+        user_trace_dbg("Switching on tracing @ 0x%lx ASID %lu\n",
+            env->active_tc.PC, env->CP0_EntryHi & 0xFF);
         env->tracing_suspended = false;
     }
 }
@@ -3566,13 +3566,14 @@ void helper_instr_stop(CPUMIPSState *env)
 /* Set instruction trace logging to user mode only. */
 void helper_instr_start_user_mode_only(CPUMIPSState *env)
 {
+    qemu_set_log(qemu_loglevel | CPU_LOG_USER_ONLY);
     user_trace_dbg("User-mode only tracing enabled at 0x%lx, ASID %lu\n",
         env->active_tc.PC, env->CP0_EntryHi & 0xFF);
     env->user_only_tracing_enabled = true;
     /* Disable tracing if we are not currently in user mode */
     if (!IN_USERSPACE(env)) {
-        env->trace_level_before_suspend = qemu_loglevel & CHERI_DEFAULT_TRACE_FLAG;
-        qemu_set_log(qemu_loglevel & ~CHERI_DEFAULT_TRACE_FLAG);
+        env->trace_level_before_suspend = qemu_loglevel & cl_default_trace_format;
+        qemu_set_log(qemu_loglevel & ~cl_default_trace_format);
         env->tracing_suspended = true;
     } else {
         env->tracing_suspended = false;
@@ -3592,6 +3593,7 @@ void helper_instr_stop_user_mode_only(CPUMIPSState *env)
     env->user_only_tracing_enabled = false;
     user_trace_dbg("User-mode only tracing disabled at 0x%lx, ASID %lu\n",
         env->active_tc.PC, env->CP0_EntryHi & 0xFF);
+    qemu_set_log(qemu_loglevel & ~CPU_LOG_USER_ONLY);
 }
 
 #ifdef CHERI_128

--- a/target-mips/op_helper.c
+++ b/target-mips/op_helper.c
@@ -3534,29 +3534,29 @@ extern int cl_default_trace_format;
 #endif
 
 /* Start instruction trace logging. */
-void helper_instr_start(CPUMIPSState *env)
+void helper_instr_start(CPUMIPSState *env, target_ulong pc)
 {
     /* Don't turn on tracing if user-mode only is selected and we are in the kernel */
     if (env->user_only_tracing_enabled && !IN_USERSPACE(env)) {
         assert(qemu_loglevel_mask(CPU_LOG_USER_ONLY));
         user_trace_dbg("Delaying tracing request at 0x%lx "
             "until next switch to user mode, ASID %lu\n",
-            env->active_tc.PC, env->CP0_EntryHi & 0xFF);
+            pc, env->CP0_EntryHi & 0xFF);
         env->trace_level_before_suspend = cl_default_trace_format;
         env->tracing_suspended = true;
     } else {
         qemu_set_log(qemu_loglevel | cl_default_trace_format);
         user_trace_dbg("Switching on tracing @ 0x%lx ASID %lu\n",
-            env->active_tc.PC, env->CP0_EntryHi & 0xFF);
+            pc, env->CP0_EntryHi & 0xFF);
         env->tracing_suspended = false;
     }
 }
 
 /* Stop instruction trace logging. */
-void helper_instr_stop(CPUMIPSState *env)
+void helper_instr_stop(CPUMIPSState *env, target_ulong pc)
 {
     user_trace_dbg("Switching off tracing @ 0x%lx ASID %lu\n",
-        env->active_tc.PC, env->CP0_EntryHi & 0xFF);
+        pc, env->CP0_EntryHi & 0xFF);
     qemu_set_log(qemu_loglevel & ~cl_default_trace_format);
     /* Make sure a kernel -> user switch does not turn on tracing */
     env->trace_level_before_suspend = 0;
@@ -3564,11 +3564,11 @@ void helper_instr_stop(CPUMIPSState *env)
 }
 
 /* Set instruction trace logging to user mode only. */
-void helper_instr_start_user_mode_only(CPUMIPSState *env)
+void helper_instr_start_user_mode_only(CPUMIPSState *env, target_ulong pc)
 {
     qemu_set_log(qemu_loglevel | CPU_LOG_USER_ONLY);
     user_trace_dbg("User-mode only tracing enabled at 0x%lx, ASID %lu\n",
-        env->active_tc.PC, env->CP0_EntryHi & 0xFF);
+        pc, env->CP0_EntryHi & 0xFF);
     env->user_only_tracing_enabled = true;
     /* Disable tracing if we are not currently in user mode */
     if (!IN_USERSPACE(env)) {
@@ -3581,18 +3581,18 @@ void helper_instr_start_user_mode_only(CPUMIPSState *env)
 }
 
 /* Stop instruction trace logging to user mode only. */
-void helper_instr_stop_user_mode_only(CPUMIPSState *env)
+void helper_instr_stop_user_mode_only(CPUMIPSState *env, target_ulong pc)
 {
     /* Disable user-mode only and restore the previous tracing level */
     if (env->tracing_suspended) {
         user_trace_dbg("User-only trace turned off -> Restoring old trace level at 0x%lx, ASID %lu\n",
-            env->active_tc.PC, env->CP0_EntryHi & 0xFF);
+            pc, env->CP0_EntryHi & 0xFF);
         qemu_set_log(qemu_loglevel | env->trace_level_before_suspend);
     }
     env->tracing_suspended = false;
     env->user_only_tracing_enabled = false;
     user_trace_dbg("User-mode only tracing disabled at 0x%lx, ASID %lu\n",
-        env->active_tc.PC, env->CP0_EntryHi & 0xFF);
+        pc, env->CP0_EntryHi & 0xFF);
     qemu_set_log(qemu_loglevel & ~CPU_LOG_USER_ONLY);
 }
 

--- a/target-mips/op_helper.c
+++ b/target-mips/op_helper.c
@@ -3649,7 +3649,7 @@ void helper_cheri_debug_message(struct CPUMIPSState* env, uint64_t pc)
     uint32_t mode = qemu_loglevel & (CPU_LOG_CVTRACE | CPU_LOG_INSTR);
     if (!mode && env->tracing_suspended) {
         /* Always print these messages even if user-space only tracing is on */
-        mode = CHERI_DEFAULT_TRACE_FLAG;
+        mode = cl_default_trace_format;
     }
     if (!mode) {
         return;
@@ -5601,9 +5601,9 @@ static void update_tracing_on_mode_change(CPUMIPSState *env, const char* new_mod
         /* When changing from user mode to kernel mode disable tracing */
         user_trace_dbg("%s -> %s: 0x%lx ASID %lu -- switching off tracing \n",
             env->last_mode, new_mode, env->active_tc.PC, env->CP0_EntryHi & 0xFF);
-        env->trace_level_before_suspend = qemu_loglevel & CHERI_DEFAULT_TRACE_FLAG;
+        env->trace_level_before_suspend = qemu_loglevel & cl_default_trace_format;
         env->tracing_suspended = true;
-        qemu_set_log(qemu_loglevel & ~CHERI_DEFAULT_TRACE_FLAG);
+        qemu_set_log(qemu_loglevel & ~cl_default_trace_format);
     } else if (strcmp(new_mode, TRACE_MODE_USER) == 0) {
         /* When changing back to user mode restore instruction tracing */
         assert(!IN_USERSPACE(env));

--- a/target-mips/translate.c
+++ b/target-mips/translate.c
@@ -4589,6 +4589,14 @@ static void gen_logic_imm(DisasContext *ctx, uint32_t opc,
             /* With 'li $0, 0xdead' turn off instruction trace logging. */
             if ((uint16_t)imm == 0xdead)
                 gen_helper_instr_stop(cpu_env);
+
+            /* With 'li $0, 0xdeaf' switch to userspace-only instruction trace logging. */
+            if ((uint16_t)imm == 0xdeaf)
+                gen_helper_instr_start_user_mode_only(cpu_env);
+
+            /* With 'li $0, 0xfaed' switch off userspace-only instruction trace logging. */
+            if ((uint16_t)imm == 0xfaed)
+                gen_helper_instr_stop_user_mode_only(cpu_env);
         }
 #endif /* TARGET_CHERI */
         return;

--- a/target-mips/translate.c
+++ b/target-mips/translate.c
@@ -4604,6 +4604,9 @@ static void gen_logic_imm(DisasContext *ctx, uint32_t opc,
             if ((uint16_t)imm == 0xfaed)
                 GEN_CHERI_TRACE_HELPER(cpu_env, instr_stop_user_mode_only);
 
+            if ((uint16_t)imm == 0xface)
+                GEN_CHERI_TRACE_HELPER(cpu_env, cheri_debug_message);
+
         }
 #endif /* TARGET_CHERI */
         return;

--- a/target-mips/translate.c
+++ b/target-mips/translate.c
@@ -4565,6 +4565,13 @@ static void gen_arith_imm(DisasContext *ctx, uint32_t opc,
     MIPS_DEBUG("%s %s, %s, " TARGET_FMT_lx, opn, regnames[rt], regnames[rs], uimm);
 }
 
+
+#define GEN_CHERI_TRACE_HELPER(env, name) { \
+    TCGv_i64 tpc = tcg_const_i64(ctx->pc); \
+    gen_helper_##name(env, tpc); \
+    tcg_temp_free_i64(tpc); \
+}
+
 /* Logic with immediate operand */
 static void gen_logic_imm(DisasContext *ctx, uint32_t opc,
                           int rt, int rs, int16_t imm)
@@ -4581,22 +4588,22 @@ static void gen_logic_imm(DisasContext *ctx, uint32_t opc,
             if (qemu_loglevel_mask(CPU_LOG_CVTRACE))
                 return;
 #endif
-
             /* With 'li $0, 0xbeef' turn on instruction trace logging. */
             if ((uint16_t)imm == 0xbeef)
-                gen_helper_instr_start(cpu_env);
+                GEN_CHERI_TRACE_HELPER(cpu_env, instr_start);
 
             /* With 'li $0, 0xdead' turn off instruction trace logging. */
             if ((uint16_t)imm == 0xdead)
-                gen_helper_instr_stop(cpu_env);
+                GEN_CHERI_TRACE_HELPER(cpu_env, instr_stop);
 
             /* With 'li $0, 0xdeaf' switch to userspace-only instruction trace logging. */
             if ((uint16_t)imm == 0xdeaf)
-                gen_helper_instr_start_user_mode_only(cpu_env);
+                GEN_CHERI_TRACE_HELPER(cpu_env, instr_start_user_mode_only);
 
             /* With 'li $0, 0xfaed' switch off userspace-only instruction trace logging. */
             if ((uint16_t)imm == 0xfaed)
-                gen_helper_instr_stop_user_mode_only(cpu_env);
+                GEN_CHERI_TRACE_HELPER(cpu_env, instr_stop_user_mode_only);
+
         }
 #endif /* TARGET_CHERI */
         return;

--- a/target-mips/translate.c
+++ b/target-mips/translate.c
@@ -22918,9 +22918,6 @@ gen_intermediate_code_internal(MIPSCPU *cpu, TranslationBlock *tb,
     int insn_bytes;
     int is_slot;
 
-    if (search_pc && !qemu_loglevel_mask(CPU_LOG_CVTRACE))
-        qemu_log("search pc %d\n", search_pc);
-
     pc_start = tb->pc;
     next_page_start = (pc_start & TARGET_PAGE_MASK) + TARGET_PAGE_SIZE;
     ctx.pc = pc_start;


### PR DESCRIPTION
Done using special nops li 0xdeaf/0xfaed

I added a -u option to qtrace to use this and the resulting trace files are a lot smaller as TLB misses and other kernel stuff is not there anymore. Makes it a lot easier to search for a userspace failure.