### PR TITLE
Fix multiple cvtrace logging bugs when storing exception code and tag and sealed bits

### DIFF
--- a/target-mips/helper.c
+++ b/target-mips/helper.c
@@ -857,8 +857,7 @@ void mips_cpu_do_interrupt(CPUState *cs)
                     TARGET_FMT_lx "\n", cause, name, env->active_tc.PC);
     }
     if (unlikely(qemu_loglevel_mask(CPU_LOG_CVTRACE))) {
-        if (cs->exception_index != EXCP_EXT_INTERRUPT)
-            env->cvtrace.exception = cause;
+        env->cvtrace.exception = cause;
     }
 #endif /* TARGET_CHERI */
     if (qemu_loglevel_mask(CPU_LOG_INT)


### PR DESCRIPTION
The EXCP_EXT_INTERRUPT exception code is ignored and never written to the trace. This is problematic when parsing traces because we rely on the exception field to detect user/kernel switches and properly keep track of PCC, EPCC and KCC changes.
This enable logging of exception cause in cheri traces also when the exception code is EXCP_EXT_INTERRUPT.

Two other tracing bugs are fixed, the tag bit was not set correctly sometimes (see #32) and the sealed bit was not tswapped correctly when being stored in the trace.

I also moved the code that stores data into cvtrace entries in separate functions like it was already done for most of the code that dumps data to text traces.