### PR TITLE
Allow to record different traces in different logfiles during the same qemu session

### DIFF
--- a/target-mips/op_helper.c
+++ b/target-mips/op_helper.c
@@ -4182,6 +4182,7 @@ static inline void log_instruction(CPUMIPSState *env, target_ulong pc, int isa)
             buffer[0] = CVT_QEMU_VERSION;
             g_strlcpy(buffer+1, CVT_QEMU_MAGIC, sizeof(env->cvtrace)-2);
             fwrite(buffer, sizeof(env->cvtrace), 1, qemu_logfile);
+            cycles = 0;
         }
         bzero(&env->cvtrace, sizeof(env->cvtrace));
         env->cvtrace.version = CVT_NO_REG;

--- a/target-mips/op_helper.c
+++ b/target-mips/op_helper.c
@@ -4172,8 +4172,9 @@ static inline void log_instruction(CPUMIPSState *env, target_ulong pc, int isa)
         MIPSCPU *cpu = mips_env_get_cpu(env);
         CPUState *cs = CPU(cpu);
 
-        /* Write previous instruction trace to log. */
-        if (env->cvtrace.version != 0) {
+        /* if the logfile is empty we need to emit the cvt magic */
+        if (env->cvtrace.version != 0 && ftell(qemu_logfile) != 0) {
+            /* Write previous instruction trace to log. */
             fwrite(&env->cvtrace, sizeof(env->cvtrace), 1, qemu_logfile);
         } else {
             char buffer[sizeof(env->cvtrace)];


### PR DESCRIPTION
Write the cvtrace magic to a qemu logfile when the logfile is change without shutting down qemu.