### PR TITLE
Fix inconsistent tags

### DIFF
--- a/include/sysemu/dma.h
+++ b/include/sysemu/dma.h
@@ -84,22 +84,12 @@ static inline bool dma_memory_valid(AddressSpace *as,
                                       dir == DMA_DIRECTION_FROM_DEVICE);
 }
 
-/* XXX CHERI tag memory emulation needs to be moved to memory.c */
-void cheri_tag_phys_invalidate(ram_addr_t paddr, ram_addr_t len);
-
 static inline int dma_memory_rw_relaxed(AddressSpace *as, dma_addr_t addr,
                                         void *buf, dma_addr_t len,
                                         DMADirection dir)
 {
-    MemTxResult ret;
-    bool is_write = (dir == DMA_DIRECTION_FROM_DEVICE);
-
-    ret = address_space_rw(as, addr, MEMTXATTRS_UNSPECIFIED, buf, len,
-            is_write);
-    if (is_write)
-        cheri_tag_phys_invalidate(addr, len);
-
-    return (bool)ret;
+    return (bool)address_space_rw(as, addr, MEMTXATTRS_UNSPECIFIED,
+            buf, len, dir == DMA_DIRECTION_FROM_DEVICE);
 }
 
 static inline int dma_memory_read_relaxed(AddressSpace *as, dma_addr_t addr,

--- a/include/sysemu/dma.h
+++ b/include/sysemu/dma.h
@@ -85,7 +85,7 @@ static inline bool dma_memory_valid(AddressSpace *as,
 }
 
 /* XXX CHERI tag memory emulation needs to be moved to memory.c */
-void cheri_tag_phys_invalidate(hwaddr paddr, hwaddr len);
+void cheri_tag_phys_invalidate(ram_addr_t paddr, ram_addr_t len);
 
 static inline int dma_memory_rw_relaxed(AddressSpace *as, dma_addr_t addr,
                                         void *buf, dma_addr_t len,

--- a/target-mips/cpu.h
+++ b/target-mips/cpu.h
@@ -1279,7 +1279,7 @@ static inline void cpu_mips_store_cause(CPUMIPSState *env, target_ulong val)
     }
 }
 
-void cheri_tag_phys_invalidate(hwaddr paddr, hwaddr len);
+void cheri_tag_phys_invalidate(ram_addr_t paddr, ram_addr_t len);
 #if defined(TARGET_CHERI)
 void cheri_tag_init(uint64_t memory_size);
 void cheri_tag_invalidate(CPUMIPSState *env, target_ulong vaddr, int32_t size);

--- a/target-mips/helper.c
+++ b/target-mips/helper.c
@@ -974,6 +974,7 @@ void r4k_invalidate_tlb (CPUMIPSState *env, int idx, int use_extra)
 #define CAP_TAG_SHFT        5           // 5 for 256-bit caps, 4 for 128-bit
 #endif /* !(CHERI_MAGIC128 || CHERI_128) */
 #define CAP_SIZE            (1 << CAP_TAG_SHFT)
+#define CAP_MASK            ((1 << CAP_TAG_SHFT) - 1)
 #define CAP_TAGBLK_SHFT     12          // 2^12 or 4096 tags per block
 #define CAP_TAGBLK_MSK      ((1 << CAP_TAGBLK_SHFT) - 1)
 #ifdef CHERI_MAGIC128
@@ -1069,7 +1070,7 @@ void cheri_tag_phys_invalidate(hwaddr paddr, hwaddr len)
 
     endaddr = (uint64_t)(paddr + len);
 
-    for(addr = (uint64_t)(paddr & ~CAP_TAGBLK_MSK); addr < endaddr;
+    for(addr = (uint64_t)(paddr & ~CAP_MASK); addr < endaddr;
             addr += CAP_SIZE) {
         tag = addr >> CAP_TAG_SHFT;
         tagmem_idx = tag >> CAP_TAGBLK_SHFT;


### PR DESCRIPTION
[The first commit is hopefully self-explanatory, unless I'm completely misunderstanding what's going on. I haven't actually knowingly seen this cause an issue, mind you.]

Tag handling has been using physical addresses, but on Malta, the upper 2 GiB of the 32-bit address space is physically aliased to the lower 2 GiB, with the exception of the I/O area which appears only at 0x10000000 (qemu actually implements it the other way round for convenience, since the higher half is one contiguous block covering the entire RAM available).

Most of the time, the physical addresses used for a particular RAM address will consistently be either high or low memory (CheriBSD only uses 0x0-0x10000000 and 0x90000000 onwards). However, `invalidate_and_set_dirty` in exec.c is given a RAM address, not a physical address (despite the misleading `hwaddr` type), which ends up being in the lower half (0x10000000 in this case means in RAM, not the IO area). If this happens for an address beyond 0x10000000, then from CheriBSD's point of view no tags get cleared, as it uses 0x90000000 onwards, which still has any tag bits set.

I assume that an issue like this was the motivation for 9c3b1a0. However, `address_space_rw` itself will call `invalidate_and_set_dirty` if writing to RAM, so it shouldn't be needed. The call added to `dma_memory_rw_relaxed` also uses a physical address which will have come from the kernel, presumably masking the underlying issue in many cases, but some places call `address_space_rw` directly.

I haven't (yet) tried removing the call from `dma_memory_rw_relaxed`. Also, the extra 0x80000000 passed to `cheri_tag_init` can also presumably be dropped now.

Outstanding issues:

 * Are the RAM addresses always 0 to `ram_size`, i.e. can they naïvely be used as an array index like this?
 * What should happen with the ROM case? Currently it's treated the same as RAM, but in theory this index could go out of bounds of `cheri_tagmem`?
 * `lladdr` now gets translated to a RAM address, so stores to aliasing physical memory will also clear `linkflag`. I can see reasons for either way being implemented on real Malta boards.

I also noticed that there are a couple of theoretical issues with `cheri_tag_invalidate`:

 * If called with a virtual address and size straddling a page boundary, `tag2` will be for the RAM directly after `tag1`, which may not be the same RAM used by the next *virtual* page.
 * If the virtual address is not capability-aligned (perhaps you do a 1-byte write somewhere in the middle of a capability), the check against `lladdr` can fail. It seems `lladdr` is only used for `cllc` so it could instead by changed to `(ram_addr & ~CAP_MASK) == p2r_addr(env, env>lladdr)`.

EDIT: This seems related to #3, but may be something different. I have seen tagged NULL capabilities appearing, as well as tagged data, both from the final loaded program segment, which is writable data and .bss, but I think the tagged NULLs have been from allocated data sections rather than .bss.