### PR TITLE
Add support for examining capability registers via the gdb server.

### DIFF
--- a/configure
+++ b/configure
@@ -5324,17 +5324,20 @@ case "$target_name" in
   mips|mipsel)
     TARGET_ARCH=mips
     echo "TARGET_ABI_MIPSO32=y" >> $config_target_mak
+    gdb_xml_files="mips-cpu.xml mips-cp0.xml mips-fpu.xml mips-sys.xml"
   ;;
   mipsn32|mipsn32el)
     TARGET_ARCH=mips64
     TARGET_BASE_ARCH=mips
     echo "TARGET_ABI_MIPSN32=y" >> $config_target_mak
     echo "TARGET_ABI32=y" >> $config_target_mak
+    gdb_xml_files="mips64-cpu.xml mips64-cp0.xml mips64-fpu.xml mips-sys.xml"
   ;;
   mips64|mips64el)
     TARGET_ARCH=mips64
     TARGET_BASE_ARCH=mips
     echo "TARGET_ABI_MIPSN64=y" >> $config_target_mak
+    gdb_xml_files="mips64-cpu.xml mips64-cp0.xml mips64-fpu.xml mips64-sys.xml"
   ;;
   cheri)
     TARGET_ARCH=mips64
@@ -5342,6 +5345,7 @@ case "$target_name" in
     echo "TARGET_ABI_MIPSN64=y" >> $config_target_mak
     echo "TARGET_CHERI=y" >> $config_target_mak
     echo "CONFIG_CHERI=y" >> $config_host_mak
+    gdb_xml_files="mips64-cpu.xml mips64-cp0.xml mips64-fpu.xml mips64-sys.xml mips64-cheri-c128.xml mips64-cheri-c256.xml"
   ;;
   moxie)
   ;;

--- a/gdb-xml/mips-cp0.xml
+++ b/gdb-xml/mips-cp0.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2007-2017 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.mips.cp0">
+  <reg name="status" bitsize="32" regnum="32"/>
+  <reg name="badvaddr" bitsize="32" regnum="35"/>
+  <reg name="cause" bitsize="32" regnum="36"/>
+</feature>

--- a/gdb-xml/mips-cpu.xml
+++ b/gdb-xml/mips-cpu.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2007-2017 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.mips.cpu">
+  <reg name="r0" bitsize="32" regnum="0"/>
+  <reg name="r1" bitsize="32"/>
+  <reg name="r2" bitsize="32"/>
+  <reg name="r3" bitsize="32"/>
+  <reg name="r4" bitsize="32"/>
+  <reg name="r5" bitsize="32"/>
+  <reg name="r6" bitsize="32"/>
+  <reg name="r7" bitsize="32"/>
+  <reg name="r8" bitsize="32"/>
+  <reg name="r9" bitsize="32"/>
+  <reg name="r10" bitsize="32"/>
+  <reg name="r11" bitsize="32"/>
+  <reg name="r12" bitsize="32"/>
+  <reg name="r13" bitsize="32"/>
+  <reg name="r14" bitsize="32"/>
+  <reg name="r15" bitsize="32"/>
+  <reg name="r16" bitsize="32"/>
+  <reg name="r17" bitsize="32"/>
+  <reg name="r18" bitsize="32"/>
+  <reg name="r19" bitsize="32"/>
+  <reg name="r20" bitsize="32"/>
+  <reg name="r21" bitsize="32"/>
+  <reg name="r22" bitsize="32"/>
+  <reg name="r23" bitsize="32"/>
+  <reg name="r24" bitsize="32"/>
+  <reg name="r25" bitsize="32"/>
+  <reg name="r26" bitsize="32"/>
+  <reg name="r27" bitsize="32"/>
+  <reg name="r28" bitsize="32"/>
+  <reg name="r29" bitsize="32"/>
+  <reg name="r30" bitsize="32"/>
+  <reg name="r31" bitsize="32"/>
+
+  <reg name="lo" bitsize="32" regnum="33"/>
+  <reg name="hi" bitsize="32" regnum="34"/>
+  <reg name="pc" bitsize="32" regnum="37"/>
+</feature>

--- a/gdb-xml/mips-fpu.xml
+++ b/gdb-xml/mips-fpu.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2007-2017 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.mips.fpu">
+  <reg name="f0" bitsize="32" type="ieee_single" regnum="38"/>
+  <reg name="f1" bitsize="32" type="ieee_single"/>
+  <reg name="f2" bitsize="32" type="ieee_single"/>
+  <reg name="f3" bitsize="32" type="ieee_single"/>
+  <reg name="f4" bitsize="32" type="ieee_single"/>
+  <reg name="f5" bitsize="32" type="ieee_single"/>
+  <reg name="f6" bitsize="32" type="ieee_single"/>
+  <reg name="f7" bitsize="32" type="ieee_single"/>
+  <reg name="f8" bitsize="32" type="ieee_single"/>
+  <reg name="f9" bitsize="32" type="ieee_single"/>
+  <reg name="f10" bitsize="32" type="ieee_single"/>
+  <reg name="f11" bitsize="32" type="ieee_single"/>
+  <reg name="f12" bitsize="32" type="ieee_single"/>
+  <reg name="f13" bitsize="32" type="ieee_single"/>
+  <reg name="f14" bitsize="32" type="ieee_single"/>
+  <reg name="f15" bitsize="32" type="ieee_single"/>
+  <reg name="f16" bitsize="32" type="ieee_single"/>
+  <reg name="f17" bitsize="32" type="ieee_single"/>
+  <reg name="f18" bitsize="32" type="ieee_single"/>
+  <reg name="f19" bitsize="32" type="ieee_single"/>
+  <reg name="f20" bitsize="32" type="ieee_single"/>
+  <reg name="f21" bitsize="32" type="ieee_single"/>
+  <reg name="f22" bitsize="32" type="ieee_single"/>
+  <reg name="f23" bitsize="32" type="ieee_single"/>
+  <reg name="f24" bitsize="32" type="ieee_single"/>
+  <reg name="f25" bitsize="32" type="ieee_single"/>
+  <reg name="f26" bitsize="32" type="ieee_single"/>
+  <reg name="f27" bitsize="32" type="ieee_single"/>
+  <reg name="f28" bitsize="32" type="ieee_single"/>
+  <reg name="f29" bitsize="32" type="ieee_single"/>
+  <reg name="f30" bitsize="32" type="ieee_single"/>
+  <reg name="f31" bitsize="32" type="ieee_single"/>
+
+  <reg name="fcsr" bitsize="32" group="float"/>
+  <reg name="fir" bitsize="32" group="float"/>
+</feature>

--- a/gdb-xml/mips64-cheri-c128.xml
+++ b/gdb-xml/mips64-cheri-c128.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2007-2016 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.mips.cheri128">
+  <flags id="cap128_perms" size="8">
+    <field name="T" start="0" end="19"/>
+    <field name="B" start="20" end="39"/>
+    <field name="s" start="40" end="40"/>
+    <field name="e" start="41" end="46"/>
+    <field name="G" start="50" end="50"/>
+    <field name="X" start="51" end="51"/>
+    <field name="R" start="52" end="52"/>
+    <field name="W" start="53" end="53"/>
+    <field name="RC" start="54" end="54"/>
+    <field name="WC" start="55" end="55"/>
+    <field name="WLC" start="56" end="56"/>
+    <field name="S" start="57" end="57"/>
+    <field name="SR" start="59" end="59"/>
+    <field name="uP" start="60" end="63"/>
+  </flags>
+  <struct id="cheri_cap128">
+    <field name="attr" type="cap128_perms"/>
+    <field name="cursor" type="uint64"/>
+  </struct>
+
+  <reg name="c0" bitsize="128" type="cheri_cap128"/>
+  <reg name="c1" bitsize="128" type="cheri_cap128"/>
+  <reg name="c2" bitsize="128" type="cheri_cap128"/>
+  <reg name="c3" bitsize="128" type="cheri_cap128"/>
+  <reg name="c4" bitsize="128" type="cheri_cap128"/>
+  <reg name="c5" bitsize="128" type="cheri_cap128"/>
+  <reg name="c6" bitsize="128" type="cheri_cap128"/>
+  <reg name="c7" bitsize="128" type="cheri_cap128"/>
+  <reg name="c8" bitsize="128" type="cheri_cap128"/>
+  <reg name="c9" bitsize="128" type="cheri_cap128"/>
+  <reg name="c10" bitsize="128" type="cheri_cap128"/>
+  <reg name="c11" bitsize="128" type="cheri_cap128"/>
+  <reg name="c12" bitsize="128" type="cheri_cap128"/>
+  <reg name="c13" bitsize="128" type="cheri_cap128"/>
+  <reg name="c14" bitsize="128" type="cheri_cap128"/>
+  <reg name="c15" bitsize="128" type="cheri_cap128"/>
+  <reg name="c16" bitsize="128" type="cheri_cap128"/>
+  <reg name="c17" bitsize="128" type="cheri_cap128"/>
+  <reg name="c18" bitsize="128" type="cheri_cap128"/>
+  <reg name="c19" bitsize="128" type="cheri_cap128"/>
+  <reg name="c20" bitsize="128" type="cheri_cap128"/>
+  <reg name="c21" bitsize="128" type="cheri_cap128"/>
+  <reg name="c22" bitsize="128" type="cheri_cap128"/>
+  <reg name="c23" bitsize="128" type="cheri_cap128"/>
+  <reg name="c24" bitsize="128" type="cheri_cap128"/>
+  <reg name="c25" bitsize="128" type="cheri_cap128"/>
+  <reg name="c26" bitsize="128" type="cheri_cap128"/>
+  <reg name="c27" bitsize="128" type="cheri_cap128"/>
+  <reg name="c28" bitsize="128" type="cheri_cap128"/>
+  <reg name="c29" bitsize="128" type="cheri_cap128"/>
+  <reg name="c30" bitsize="128" type="cheri_cap128"/>
+  <reg name="c31" bitsize="128" type="cheri_cap128"/>
+
+  <reg name="pcc" bitsize="128" type="cheri_cap128"/>
+
+  <flags id="cap_cause" size="8">
+    <field name="reg" start="0" end="7"/>
+    <field name="exccode" start="8" end="15"/>
+  </flags>
+  <reg name="cap_cause" bitsize="64" type="cap_cause"/>
+  <reg name="cap_valid" bitsize="64"/>
+</feature>

--- a/gdb-xml/mips64-cheri-c256.xml
+++ b/gdb-xml/mips64-cheri-c256.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2007-2016 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.mips.cheri256">
+  <flags id="cap256_perms" size="8">
+    <field name="s" start="0" end="0"/>
+    <field name="G" start="1" end="1"/>
+    <field name="X" start="2" end="2"/>
+    <field name="R" start="3" end="3"/>
+    <field name="W" start="4" end="4"/>
+    <field name="RC" start="5" end="5"/>
+    <field name="WC" start="6" end="6"/>
+    <field name="WLC" start="7" end="7"/>
+    <field name="S" start="8" end="8"/>
+    <field name="SR" start="11" end="11"/>
+    <field name="uP" start="16" end="31"/>
+    <field name="type" start="32" end="55"/>
+  </flags>
+  <struct id="cheri_cap256">
+    <field name="attr" type="cap256_perms"/>
+    <field name="cursor" type="uint64"/>
+    <field name="base" type="uint64"/>
+    <field name="length" type="uint64"/>
+  </struct>
+
+  <reg name="c0" bitsize="256" type="cheri_cap256"/>
+  <reg name="c1" bitsize="256" type="cheri_cap256"/>
+  <reg name="c2" bitsize="256" type="cheri_cap256"/>
+  <reg name="c3" bitsize="256" type="cheri_cap256"/>
+  <reg name="c4" bitsize="256" type="cheri_cap256"/>
+  <reg name="c5" bitsize="256" type="cheri_cap256"/>
+  <reg name="c6" bitsize="256" type="cheri_cap256"/>
+  <reg name="c7" bitsize="256" type="cheri_cap256"/>
+  <reg name="c8" bitsize="256" type="cheri_cap256"/>
+  <reg name="c9" bitsize="256" type="cheri_cap256"/>
+  <reg name="c10" bitsize="256" type="cheri_cap256"/>
+  <reg name="c11" bitsize="256" type="cheri_cap256"/>
+  <reg name="c12" bitsize="256" type="cheri_cap256"/>
+  <reg name="c13" bitsize="256" type="cheri_cap256"/>
+  <reg name="c14" bitsize="256" type="cheri_cap256"/>
+  <reg name="c15" bitsize="256" type="cheri_cap256"/>
+  <reg name="c16" bitsize="256" type="cheri_cap256"/>
+  <reg name="c17" bitsize="256" type="cheri_cap256"/>
+  <reg name="c18" bitsize="256" type="cheri_cap256"/>
+  <reg name="c19" bitsize="256" type="cheri_cap256"/>
+  <reg name="c20" bitsize="256" type="cheri_cap256"/>
+  <reg name="c21" bitsize="256" type="cheri_cap256"/>
+  <reg name="c22" bitsize="256" type="cheri_cap256"/>
+  <reg name="c23" bitsize="256" type="cheri_cap256"/>
+  <reg name="c24" bitsize="256" type="cheri_cap256"/>
+  <reg name="c25" bitsize="256" type="cheri_cap256"/>
+  <reg name="c26" bitsize="256" type="cheri_cap256"/>
+  <reg name="c27" bitsize="256" type="cheri_cap256"/>
+  <reg name="c28" bitsize="256" type="cheri_cap256"/>
+  <reg name="c29" bitsize="256" type="cheri_cap256"/>
+  <reg name="c30" bitsize="256" type="cheri_cap256"/>
+  <reg name="c31" bitsize="256" type="cheri_cap256"/>
+
+  <reg name="pcc" bitsize="256" type="cheri_cap256"/>
+
+  <flags id="cap_cause" size="8">
+    <field name="reg" start="0" end="7"/>
+    <field name="exccode" start="8" end="15"/>
+  </flags>
+  <reg name="cap_cause" bitsize="64" type="cap_cause"/>
+  <reg name="cap_valid" bitsize="64"/>
+</feature>

--- a/gdb-xml/mips64-cp0.xml
+++ b/gdb-xml/mips64-cp0.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2007-2017 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.mips.cp0">
+  <reg name="status" bitsize="64" regnum="32"/>
+  <reg name="badvaddr" bitsize="64" regnum="35"/>
+  <reg name="cause" bitsize="64" regnum="36"/>
+</feature>

--- a/gdb-xml/mips64-cpu.xml
+++ b/gdb-xml/mips64-cpu.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2007-2017 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.mips.cpu">
+  <reg name="r0" bitsize="64" regnum="0"/>
+  <reg name="r1" bitsize="64"/>
+  <reg name="r2" bitsize="64"/>
+  <reg name="r3" bitsize="64"/>
+  <reg name="r4" bitsize="64"/>
+  <reg name="r5" bitsize="64"/>
+  <reg name="r6" bitsize="64"/>
+  <reg name="r7" bitsize="64"/>
+  <reg name="r8" bitsize="64"/>
+  <reg name="r9" bitsize="64"/>
+  <reg name="r10" bitsize="64"/>
+  <reg name="r11" bitsize="64"/>
+  <reg name="r12" bitsize="64"/>
+  <reg name="r13" bitsize="64"/>
+  <reg name="r14" bitsize="64"/>
+  <reg name="r15" bitsize="64"/>
+  <reg name="r16" bitsize="64"/>
+  <reg name="r17" bitsize="64"/>
+  <reg name="r18" bitsize="64"/>
+  <reg name="r19" bitsize="64"/>
+  <reg name="r20" bitsize="64"/>
+  <reg name="r21" bitsize="64"/>
+  <reg name="r22" bitsize="64"/>
+  <reg name="r23" bitsize="64"/>
+  <reg name="r24" bitsize="64"/>
+  <reg name="r25" bitsize="64"/>
+  <reg name="r26" bitsize="64"/>
+  <reg name="r27" bitsize="64"/>
+  <reg name="r28" bitsize="64"/>
+  <reg name="r29" bitsize="64"/>
+  <reg name="r30" bitsize="64"/>
+  <reg name="r31" bitsize="64"/>
+
+  <reg name="lo" bitsize="64" regnum="33"/>
+  <reg name="hi" bitsize="64" regnum="34"/>
+  <reg name="pc" bitsize="64" regnum="37"/>
+</feature>

--- a/gdb-xml/mips64-fpu.xml
+++ b/gdb-xml/mips64-fpu.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2007-2017 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.mips.fpu">
+  <reg name="f0" bitsize="64" type="ieee_double" regnum="38"/>
+  <reg name="f1" bitsize="64" type="ieee_double"/>
+  <reg name="f2" bitsize="64" type="ieee_double"/>
+  <reg name="f3" bitsize="64" type="ieee_double"/>
+  <reg name="f4" bitsize="64" type="ieee_double"/>
+  <reg name="f5" bitsize="64" type="ieee_double"/>
+  <reg name="f6" bitsize="64" type="ieee_double"/>
+  <reg name="f7" bitsize="64" type="ieee_double"/>
+  <reg name="f8" bitsize="64" type="ieee_double"/>
+  <reg name="f9" bitsize="64" type="ieee_double"/>
+  <reg name="f10" bitsize="64" type="ieee_double"/>
+  <reg name="f11" bitsize="64" type="ieee_double"/>
+  <reg name="f12" bitsize="64" type="ieee_double"/>
+  <reg name="f13" bitsize="64" type="ieee_double"/>
+  <reg name="f14" bitsize="64" type="ieee_double"/>
+  <reg name="f15" bitsize="64" type="ieee_double"/>
+  <reg name="f16" bitsize="64" type="ieee_double"/>
+  <reg name="f17" bitsize="64" type="ieee_double"/>
+  <reg name="f18" bitsize="64" type="ieee_double"/>
+  <reg name="f19" bitsize="64" type="ieee_double"/>
+  <reg name="f20" bitsize="64" type="ieee_double"/>
+  <reg name="f21" bitsize="64" type="ieee_double"/>
+  <reg name="f22" bitsize="64" type="ieee_double"/>
+  <reg name="f23" bitsize="64" type="ieee_double"/>
+  <reg name="f24" bitsize="64" type="ieee_double"/>
+  <reg name="f25" bitsize="64" type="ieee_double"/>
+  <reg name="f26" bitsize="64" type="ieee_double"/>
+  <reg name="f27" bitsize="64" type="ieee_double"/>
+  <reg name="f28" bitsize="64" type="ieee_double"/>
+  <reg name="f29" bitsize="64" type="ieee_double"/>
+  <reg name="f30" bitsize="64" type="ieee_double"/>
+  <reg name="f31" bitsize="64" type="ieee_double"/>
+
+  <reg name="fcsr" bitsize="64" group="float"/>
+  <reg name="fir" bitsize="64" group="float"/>
+</feature>

--- a/target-mips/cpu-qom.h
+++ b/target-mips/cpu-qom.h
@@ -78,6 +78,12 @@ static inline MIPSCPU *mips_env_get_cpu(CPUMIPSState *env)
 extern const struct VMStateDescription vmstate_mips_cpu;
 #endif
 
+#ifdef TARGET_CHERI
+int mips_gdb_get_cheri_reg(CPUMIPSState *env, uint8_t *mem_buf, int n);
+int mips_gdb_set_cheri_reg(CPUMIPSState *env, uint8_t *mem_buf, int n);
+#endif
+int mips_gdb_get_sys_reg(CPUMIPSState *env, uint8_t *mem_buf, int n);
+int mips_gdb_set_sys_reg(CPUMIPSState *env, uint8_t *mem_buf, int n);
 void mips_cpu_do_interrupt(CPUState *cpu);
 bool mips_cpu_exec_interrupt(CPUState *cpu, int int_req);
 void mips_cpu_dump_state(CPUState *cpu, FILE *f, fprintf_function cpu_fprintf,

--- a/target-mips/gdbstub.c
+++ b/target-mips/gdbstub.c
@@ -59,16 +59,6 @@ int mips_cpu_gdb_read_register(CPUState *cs, uint8_t *mem_buf, int n)
     case 37:
         return gdb_get_regl(mem_buf, env->active_tc.PC |
                                      !!(env->hflags & MIPS_HFLAG_M16));
-    case 72:
-        return gdb_get_regl(mem_buf, 0); /* fp */
-    case 89:
-        return gdb_get_regl(mem_buf, (int32_t)env->CP0_PRid);
-    default:
-        if (n > 89) {
-            return 0;
-        }
-        /* 16 embedded regs.  */
-        return gdb_get_regl(mem_buf, 0);
     }
 
     return 0;
@@ -136,10 +126,8 @@ int mips_cpu_gdb_write_register(CPUState *cs, uint8_t *mem_buf, int n)
             env->hflags &= ~(MIPS_HFLAG_M16);
         }
         break;
-    case 72: /* fp, ignored */
-        break;
     default:
-        if (n > 89) {
+        if (n > 72) {
             return 0;
         }
         /* Other registers are readonly.  Ignore writes.  */
@@ -148,3 +136,93 @@ int mips_cpu_gdb_write_register(CPUState *cs, uint8_t *mem_buf, int n)
 
     return sizeof(target_ulong);
 }
+
+int mips_gdb_get_sys_reg(CPUMIPSState *env, uint8_t *mem_buf, int n)
+{
+    if (n == 0)
+        return gdb_get_regl(mem_buf, (int32_t)env->CP0_PRid);
+
+    return 0;
+}
+
+int mips_gdb_set_sys_reg(CPUMIPSState *env, uint8_t *mem_buf, int n)
+{
+    /* System registers are readonly.  Ignore writes.  */
+    if (n == 0)
+	return sizeof(target_ulong);
+
+    return 0;
+}
+
+#if defined(TARGET_CHERI)
+static int gdb_get_capreg(uint8_t *mem_buf, cap_register_t *cap)
+{
+#ifdef CHERI_128
+    stq_p(mem_buf, cap->cr_pesbt);
+    stq_p(mem_buf + 8, cap->cr_base + cap->cr_offset);
+    return 16;
+#elif defined(CHERI_MAGIC128)
+    /* XXX: Would need to generate pesbt. */
+    stq_p(mem_buf, 0);
+    stq_p(mem_buf + 8, cap->cr_base + cap->cr_offset);
+    return 16;
+#else
+    target_ulong ret;
+    uint64_t perms;
+
+    perms = (uint64_t)(((cap->cr_uperms & CAP_UPERMS_ALL) << CAP_UPERMS_SHFT) |
+        (cap->cr_perms & CAP_PERMS_ALL));
+
+    ret = ((uint64_t)cap->cr_otype << 32) |
+        (perms << 1) | (cap->cr_sealed ? 1UL : 0UL);
+	
+    stq_p(mem_buf, ret);
+    stq_p(mem_buf + 8, cap->cr_base + cap->cr_offset);
+    stq_p(mem_buf + 16, cap->cr_base);
+    stq_p(mem_buf + 24, cap->cr_length);
+    return 32;
+#endif
+}
+
+int mips_gdb_get_cheri_reg(CPUMIPSState *env, uint8_t *mem_buf, int n)
+{
+    if (n < 32)
+	return gdb_get_capreg(mem_buf, &env->active_tc.C[n]);
+    switch (n) {
+    case 32:
+	return gdb_get_capreg(mem_buf, &env->active_tc.PCC);
+    case 33:
+	return gdb_get_regl(mem_buf, env->CP2_CapCause);
+    case 34: {
+	uint64_t cap_valid;
+	int i;
+
+	cap_valid = 0;
+	for (i = 0; i < 32; i++) {
+	    if (env->active_tc.C[i].cr_tag)
+		cap_valid |= ((uint64_t)1 << i);
+	}
+	if (env->active_tc.PCC.cr_tag)
+	    cap_valid |= ((uint64_t)1 << 32);
+	return gdb_get_regl(mem_buf, cap_valid);
+    }
+    }
+
+    return 0;
+}
+
+int mips_gdb_set_cheri_reg(CPUMIPSState *env, uint8_t *mem_buf, int n)
+{
+    /* All CHERI registers are read-only currently.  */
+    if (n < 33)
+#if defined(CHERI_128) || defined(CHERI_MAGIC128)
+	return 16;
+#else
+        return 32;
+#endif
+    if (n == 33 || n == 34)
+	return 8;
+
+    return 0;
+}
+#endif


### PR DESCRIPTION
This changes the MIPS backend to support GDB's XML target descriptions
for registers.  Among other things this required fixing the base MIPS
support first to remove nonstandard registers (16 "blank" embedded
registers that were always 0 and "prid") out of the "normal" GDB
register operations.

I've kept "prid" in a new "mips-sys" feature, but dropped the 16
always-zero "embedded" registers.

I then added the CHERI 128/256 bit capability register sets using
the same XML descriptions as CHERI GDB.  Note that I didn't see
an easy way to reconstruct the 64-bit attributes word for the
CHERI_MAGIC128 case, so the attributes are 0.

One other oddity I've found is that $PCC seems to be one instruction
behind $PC in the per-CPU register state.