### PR TITLE
Multi build

### DIFF
--- a/Makefile.objs
+++ b/Makefile.objs
@@ -60,7 +60,7 @@ common-obj-y += bt-host.o bt-vhci.o
 bt-host.o-cflags := $(BLUEZ_CFLAGS)
 
 common-obj-y += dma-helpers.o
-common-obj-y += vl.o
+target-obj-y += vl.o
 vl.o-cflags := $(GPROF_CFLAGS) $(SDL_CFLAGS)
 common-obj-y += tpm.o
 

--- a/Makefile.target
+++ b/Makefile.target
@@ -15,6 +15,20 @@ QEMU_CFLAGS += -I.. -I$(SRC_PATH)/target/$(TARGET_BASE_ARCH) -DNEED_CPU_H
 
 QEMU_CFLAGS+=-I$(SRC_PATH)/include
 
+ifdef CONFIG_CHERI128
+QEMU_CFLAGS+=-DCHERI_128=1
+else
+ifdef CONFIG_CHERI128_MAGIC
+QEMU_CFLAGS+=-DCHERI_MAGIC128=1
+else
+ifdef CONFIG_CHERI256
+ifneq (,$(findstring -DCHERI_,$(QEMU_CFLAGS)))
+$(error "No -DCHERI_ flags should be set when targetting CHERI256")
+endif
+endif
+endif
+endif
+
 ifdef CONFIG_USER_ONLY
 # user emulator name
 QEMU_PROG=qemu-$(TARGET_NAME)

--- a/configure
+++ b/configure
@@ -6190,7 +6190,7 @@ target_name=$(echo $target | cut -d '-' -f 1)
 target_bigendian="no"
 
 case "$target_name" in
-  armeb|hppa|lm32|m68k|microblaze|mips|mipsn32|mips64|cheri|moxie|or1k|ppc|ppcemb|ppc64|ppc64abi32|s390x|sh4eb|sparc|sparc64|sparc32plus|xtensaeb)
+  armeb|hppa|lm32|m68k|microblaze|mips|mipsn32|mips64|cheri|cheri128|cheri256|cheri128magic|moxie|or1k|ppc|ppcemb|ppc64|ppc64abi32|s390x|sh4eb|sparc|sparc64|sparc32plus|xtensaeb)
   target_bigendian=yes
   ;;
 esac

--- a/configure
+++ b/configure
@@ -6283,7 +6283,7 @@ case "$target_name" in
     echo "TARGET_ABI_MIPSN64=y" >> $config_target_mak
     gdb_xml_files="mips64-cpu.xml mips64-cp0.xml mips64-fpu.xml mips64-sys.xml"
   ;;
-  cheri)
+  cheri|cheri256|cheri128|cheri128magic)
     TARGET_ARCH=mips64
     TARGET_BASE_ARCH=mips
     echo "TARGET_ABI_MIPSN64=y" >> $config_target_mak

--- a/default-configs/cheri128-softmmu.mak
+++ b/default-configs/cheri128-softmmu.mak
@@ -1,0 +1,4 @@
+# Default configuration for cheri128-softmmu
+
+include cheri-softmmu.mak
+CONFIG_CHERI128=y

--- a/default-configs/cheri128magic-softmmu.mak
+++ b/default-configs/cheri128magic-softmmu.mak
@@ -1,0 +1,4 @@
+# Default configuration for cheri128magic-softmmu
+
+include cheri-softmmu.mak
+CONFIG_CHERI128_MAGIC=y

--- a/default-configs/cheri256-softmmu.mak
+++ b/default-configs/cheri256-softmmu.mak
@@ -1,0 +1,4 @@
+# Default configuration for cheri256-softmmu
+
+include cheri-softmmu.mak
+CONFIG_CHERI256=y

--- a/vl.c
+++ b/vl.c
@@ -1934,6 +1934,15 @@ static void version(void)
 {
     printf("QEMU emulator version " QEMU_VERSION QEMU_PKGVERSION "\n"
            QEMU_COPYRIGHT "\n");
+#ifdef TARGET_CHERI
+#ifdef CHERI_128
+    printf("Compiled for CHERI128\n");
+#elif defined(CHERI_MAGIC128)
+    printf("Compiled for CHERI128 (magic)\n");
+#else
+    printf("Compiled for CHERI256\n");
+#endif
+#endif
 }
 
 static void help(int exitcode)


### PR DESCRIPTION
Allow building for 128/magic128/256 at the same time using `./configure --target="cheri256-softmmu,cheri128-softmmu,cheri128magic-softmmu"`

I also added what CHERI flavour is being targeted to `--version`.