### PR TITLE
Add a symbolize-cheri-trace.py file to add symbol names to a text trace

### DIFF
--- a/configure
+++ b/configure
@@ -5096,6 +5096,9 @@ if [ "$guest_agent" != "no" ]; then
   fi
 fi
 
+# Add the CHERI symbolize trace script to tools:
+tools="scripts/symbolize-cheri-trace.py $tools"
+
 # Guest agent Window MSI  package
 
 if test "$guest_agent" != yes; then

--- a/scripts/symbolize-cheri-trace.py
+++ b/scripts/symbolize-cheri-trace.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+import argparse
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+
+address_regex = re.compile(b"^(0x[a-f0-9]+):")
+UNKNOWN_ADDRESS = b"??:0\n"
+
+
+def yamon_symbol_name(name: bytes, start_addr: int, addr: int):
+    offset = str(addr - start_addr).encode("utf-8")
+    return b"YAMON " + name + b" + " + offset + b"\n"
+
+
+def symbolize_line(addr2line: subprocess.Popen, line: bytes) -> bytes:
+    if not line.startswith(b"0x"):
+        return line
+    match = address_regex.match(line)
+    if not match:
+        return line
+    address = match.group(1)
+    addr2line.stdin.write(address + b"\n")
+    addr2line.stdin.flush()
+    symbol = addr2line.stdout.readline()
+    # Also symbolize bootloader addresses
+    if symbol == UNKNOWN_ADDRESS:
+        addrhex = int(address, 16)
+        if 0xffffffffbfc00580 <= addrhex < 0xffffffffbfc00800:
+            symbol = yamon_symbol_name(b"start", 0xffffffffbfc00580, addrhex)
+        elif 0xffffffffbfc00800 <= addrhex < 0xffffffffbfc00808:
+            symbol = b"YAMON unimplemented\n"
+        elif 0xffffffffbfc00808 <= addrhex < 0xffffffffbfc0083c:
+            symbol = yamon_symbol_name(b"print", 0xffffffffbfc00808, addrhex)
+        elif 0xffffffffbfc0083c <= addrhex < 0xffffffffbfc00870:
+            symbol = yamon_symbol_name(b"print_count", 0xffffffffbfc0083c, addrhex)
+        elif 0xffffffffbfc00870 <= addrhex < 0xffffffffbfc00898:
+            symbol = yamon_symbol_name(b"outch", 0xffffffffbfc00870, addrhex)
+
+    length = len(line)
+    if length < 30:
+        separator = b"\t\t\t\t# "
+    elif length < 37:
+        separator = b"\t\t\t# "
+    elif length < 43:
+        separator = b"\t\t# "
+    else:
+        separator = b"\t# "
+    return line[:-1] + separator + symbol
+
+
+def default_addr2line():
+    val = os.getenv("ADDR2LINE")
+    if not val:
+        in_sdk = os.path.join(os.getenv("CHERI_SDK", "/"), "addr2line")
+        if os.path.isfile(in_sdk):
+            return in_sdk
+    if not val:
+        val = shutil.which("addr2line")
+    return val
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--addr2line", metavar="ADDR2LINE", help="Path to addr2line", default=default_addr2line())
+    parser.add_argument("LOGFILE", help="The LOGFILE to symbolize")
+    # TODO: allow multiple (kernel + userspace?)
+    parser.add_argument("BINARY", help="The binary to use for symbols to pass to the binary")
+    args = parser.parse_args()
+
+    with Path(args.LOGFILE).open("rb") as logfile:
+        with subprocess.Popen([args.addr2line, "-e", args.BINARY], stdout=subprocess.PIPE,
+                              stdin=subprocess.PIPE) as addr2line:
+            for line in logfile.readlines():
+                sys.stdout.buffer.write(symbolize_line(addr2line, line))


### PR DESCRIPTION
It just runs addr2line on every program counter address and has some
special cases to handle the YAMON bootloader functions.

Adding this as a pull request instead of just committing since I'm not sure if installing by default is okay.

Example symbolized trace: https://gist.github.com/arichardson/b2b399ffda57a4e8b23c08687fd80a72