### PR TITLE
Implement the icount statcounter

### DIFF
--- a/target/mips/cpu.h
+++ b/target/mips/cpu.h
@@ -837,6 +837,10 @@ struct CPUMIPSState {
     bool user_only_tracing_enabled;
     bool trace_explicitly_disabled;
     bool tracing_suspended;
+
+    /* BERI Statcounters: */
+    uint64_t statcounters_icount;
+    /* TODO: we could implement the TLB ones as well */
 #endif /* TARGET_CHERI */
 
     /* Fields up to this point are cleared by a CPU reset */

--- a/target/mips/op_helper.c
+++ b/target/mips/op_helper.c
@@ -4827,7 +4827,6 @@ void helper_ccheck_pc(CPUMIPSState *env, uint64_t pc, int isa)
     cap_register_t *pcc = &env->active_tc.PCC;
     CPUState *cs = CPU(mips_env_get_cpu(env));
 
-    // TODO: increment icount?
     /* Decrement the startup breakcount, if set. */
     if (unlikely(cs->breakcount)) {
         cs->breakcount--;
@@ -4835,6 +4834,8 @@ void helper_ccheck_pc(CPUMIPSState *env, uint64_t pc, int isa)
             helper_raise_exception(env, EXCP_DEBUG);
         }
     }
+    /* Update statcounters icount */
+    env->statcounters_icount++;
 
 #ifdef CHERI_128
     /* Check tag before updating offset. */
@@ -5838,7 +5839,7 @@ target_ulong helper_rdhwr_xnp(CPUMIPSState *env)
 target_ulong helper_rdhwr_statcounters_icount(CPUMIPSState *env)
 {
     check_hwrena(env, 4, GETPC());
-    return 0x12345;
+    return env->statcounters_icount;
 }
 
 target_ulong helper_rdhwr_statcounters_reset(CPUMIPSState *env)


### PR DESCRIPTION
I am not sure if the instruction counter information already exists
somewhere else in QEMU so I am adding this as a pull request instead of
committing directly.