### PR TITLE
CHERI: CLC: all reads before updates

### DIFF
--- a/target/mips/cpu.h
+++ b/target/mips/cpu.h
@@ -312,17 +312,6 @@ get_capreg_0_is_ddc(TCState* state, unsigned num) {
     return &state->_CGPR[num];
 }
 
-// FIXME: remove the last few users of this function
-static inline  __attribute__((always_inline)) cap_register_t*
-get_writable_capreg_raw(TCState* state, unsigned num) {
-    if (unlikely(num == 0)) {
-        // writing to $c0/$cnull is a no-op -> make users of this function write to a dummy
-        static cap_register_t dummy_reg;
-        return &dummy_reg;
-    }
-    return &state->_CGPR[num];
-}
-
 static inline void
 update_capreg(TCState* state, unsigned num, const cap_register_t* newval) {
     // writing to $c0/$cnull is a no-op


### PR DESCRIPTION
In the case that CLC is loading through and storing to the same
register, it's important to check the permission bits before updating
any of the register.  In particular, we must decide to clear tags
based on missing Permit_Load_Cap of the actual source, not the
capability we loaded.