### PR TITLE
 When storing a capability, take the faults first

### DIFF
--- a/target/mips/helper.c
+++ b/target/mips/helper.c
@@ -1182,7 +1182,7 @@ void mips_cpu_do_interrupt(CPUState *cs)
                  " %s exception, (hflags & MIPS_HFLAG_BMASK)=%x\n", __func__, env->active_tc.PC, get_CP0_EPC(env),
                  name, env->hflags & MIPS_HFLAG_BMASK);
 #ifdef TARGET_CHERI
-        qemu_log("\tPCC=" PRINT_CAP_FMTSTR " KCC= " PRINT_CAP_FMTSTR "EPCC=" PRINT_CAP_FMTSTR "\n",
+        qemu_log("\tPCC=" PRINT_CAP_FMTSTR "\n\tKCC= " PRINT_CAP_FMTSTR "\n\tEPCC=" PRINT_CAP_FMTSTR "\n",
                  PRINT_CAP_ARGS(&env->active_tc.PCC), PRINT_CAP_ARGS(&env->active_tc.CHWR.KCC),
                  PRINT_CAP_ARGS(&env->active_tc.CHWR.EPCC));
 #endif

--- a/target/mips/helper.c
+++ b/target/mips/helper.c
@@ -1815,8 +1815,15 @@ void cheri_tag_invalidate(CPUMIPSState *env, target_ulong vaddr, int32_t size, u
         error_report("%s", buffer);
         exit(1);
     }
+
+    /*
+     * When resolving this address in the TLB, treat it like a data store
+     * (MMU_DATA_STORE) rather than a capability store (MMU_DATA_CAP_STORE),
+     * so that we don't require that the SC inhibit be clear.
+     */
+
     MemoryRegion* mr = NULL;
-    hwaddr paddr = v2p_addr(env, vaddr, 0, 0xFF, pc);
+    hwaddr paddr = v2p_addr(env, vaddr, MMU_DATA_STORE, 0xFF, pc);
     ram_addr_t ram_addr = p2r_addr(env, paddr, &mr);
     // Generate a trap if we try to clear tags in ROM instead of crashing
     check_tagmem_writable(env, vaddr, paddr, ram_addr, mr, pc);


### PR DESCRIPTION
The tag store has strictly more requirements of the TLB entry than a
data store.  We need the TLB entry not just to be present and to have
its write permit asserted, as with a data store, but also have the
cap-store inhibit clear.  If we store data first, we might mutate memory
but leave cap-store inhibit set, which will result in the retry storing
the first half of a capability, but not the tag, before faulting again.

This is possibly usually fine, because the entire instruction will
commit eventually, though qemu might take the faults to be an
opportunity to switch between CPUs.  But this non-atomicity is
absolutely catastrophic for cllc/cscc loops, because the faults will
break the cscc, the stores will not be retried, and the partial write
will then be loaded in the next cllc.

Update all three store_cap_to_memory (128, m128, 256) to store the tag
first.  Update the TLB mapping function to do the CHERI-specific checks
after the generic ones, so that the TLB (data) store fault, if
applicable, happens first.