### PR TITLE
Improve handling of PCC.base

### DIFF
--- a/target/mips/cpu.h
+++ b/target/mips/cpu.h
@@ -1446,8 +1446,9 @@ static inline void cpu_get_tb_cpu_state(CPUMIPSState *env, target_ulong *pc,
 {
     *pc = PC_ADDR(env);
 #ifdef TARGET_CHERI
-    *cs_base = 0;
+    *cs_base = cap_get_base(&env->active_tc.PCC);
 #else
+    *cs_base = 0;
 #endif
     *flags = env->hflags & (MIPS_HFLAG_TMASK | MIPS_HFLAG_BMASK |
                             MIPS_HFLAG_HWRENA_ULR);

--- a/target/riscv/insn_trans/trans_rvi.inc.c
+++ b/target/riscv/insn_trans/trans_rvi.inc.c
@@ -60,12 +60,8 @@ static bool trans_jalr(DisasContext *ctx, arg_jalr *a)
 
 
     gen_get_gpr(cpu_pc, a->rs1);
-#ifdef TARGET_CHERI
     // For CHERI the jump destination is an offset relative to PCC.base
-    tcg_gen_addi_tl(cpu_pc, cpu_pc, a->imm + ctx->pcc_base);
-#else
-    tcg_gen_addi_tl(cpu_pc, cpu_pc, a->imm);
-#endif
+    tcg_gen_addi_tl(cpu_pc, cpu_pc, a->imm + pcc_base(ctx));
     tcg_gen_andi_tl(cpu_pc, cpu_pc, (target_ulong)-2);
     gen_mark_pc_updated();
 
@@ -75,12 +71,8 @@ static bool trans_jalr(DisasContext *ctx, arg_jalr *a)
         tcg_gen_brcondi_tl(TCG_COND_NE, t0, 0x0, misaligned);
     }
 
-#ifdef TARGET_CHERI
-    gen_set_gpr_const(a->rd, ctx->pc_succ_insn);
-#else
     // For CHERI the result is an offset relative to PCC.base
-    gen_set_gpr_const(a->rd, ctx->pc_succ_insn - ctx->pcc_base);
-#endif
+    gen_set_gpr_const(a->rd, ctx->pc_succ_insn - pcc_base(ctx));
     gen_rvfi_dii_validate_jump(ctx);
     lookup_and_goto_ptr(ctx);
 

--- a/target/riscv/insn_trans/trans_rvi.inc.c
+++ b/target/riscv/insn_trans/trans_rvi.inc.c
@@ -42,7 +42,8 @@ static bool trans_auipc(DisasContext *ctx, arg_auipc *a)
         return true;
     }
 #endif
-    gen_set_gpr_const(a->rd, a->imm + ctx->base.pc_next);
+    // AUIPC returns a value relative to PCC.base
+    gen_set_gpr_const(a->rd, a->imm + ctx->base.pc_next - pcc_base(ctx));
     return true;
 }
 

--- a/target/riscv/insn_trans/trans_rvi.inc.c
+++ b/target/riscv/insn_trans/trans_rvi.inc.c
@@ -60,7 +60,12 @@ static bool trans_jalr(DisasContext *ctx, arg_jalr *a)
 
 
     gen_get_gpr(cpu_pc, a->rs1);
+#ifdef TARGET_CHERI
+    // For CHERI the jump destination is an offset relative to PCC.base
+    tcg_gen_addi_tl(cpu_pc, cpu_pc, a->imm + ctx->pcc_base);
+#else
     tcg_gen_addi_tl(cpu_pc, cpu_pc, a->imm);
+#endif
     tcg_gen_andi_tl(cpu_pc, cpu_pc, (target_ulong)-2);
     gen_mark_pc_updated();
 
@@ -70,7 +75,12 @@ static bool trans_jalr(DisasContext *ctx, arg_jalr *a)
         tcg_gen_brcondi_tl(TCG_COND_NE, t0, 0x0, misaligned);
     }
 
+#ifdef TARGET_CHERI
     gen_set_gpr_const(a->rd, ctx->pc_succ_insn);
+#else
+    // For CHERI the result is an offset relative to PCC.base
+    gen_set_gpr_const(a->rd, ctx->pc_succ_insn - ctx->pcc_base);
+#endif
     gen_rvfi_dii_validate_jump(ctx);
     lookup_and_goto_ptr(ctx);
 

--- a/target/riscv/translate.c
+++ b/target/riscv/translate.c
@@ -72,6 +72,15 @@ typedef struct DisasContext {
 #endif
 } DisasContext;
 
+static inline target_ulong pcc_base(DisasContext *ctx)
+{
+#ifdef TARGET_CHERI
+    return ctx->pcc_base;
+#else
+    return 0;
+#endif
+}
+
 #ifdef TARGET_RISCV64
 /* convert riscv funct3 to qemu memop for load/store */
 static const int tcg_memop_lookup[8] = {

--- a/target/riscv/translate.c
+++ b/target/riscv/translate.c
@@ -51,6 +51,9 @@ typedef struct DisasContext {
     DisasContextBase base;
     /* pc_succ_insn points to the instruction following base.pc_next */
     target_ulong pc_succ_insn;
+#ifdef TARGET_CHERI
+    target_ulong pcc_base;
+#endif
     target_ulong priv_ver;
     bool virt_enabled;
     uint32_t opcode;
@@ -957,6 +960,8 @@ static void riscv_tr_init_disas_context(DisasContextBase *dcbase, CPUState *cs)
     ctx->mstatus_fs = ctx->base.tb->flags & TB_FLAGS_MSTATUS_FS;
 #ifdef TARGET_CHERI
     ctx->capmode = (ctx->base.tb->flags & TB_FLAGS_CAPMODE) != 0;
+    ctx->pcc_base = dcbase->tb->cs_base;
+    cheri_debug_assert(ctx->pcc_base == cap_get_base(cheri_get_recent_pcc(env)));
 #endif
     ctx->priv_ver = env->priv_ver;
 #if !defined(CONFIG_USER_ONLY)


### PR DESCRIPTION
This allows us to simplify branch/jal instructions since the base of PCC is
known at translate time. cs_base is used in the TranslationBlock equality
check so two calls to the same code with different pcc.base will not result
in incorrect values being generated (since we will re-translate it).