### PR TITLE
Improve performance by moving branch target checks into translation

### DIFF
--- a/accel/tcg/translator.c
+++ b/accel/tcg/translator.c
@@ -18,9 +18,6 @@
 #include "exec/translator.h"
 #include "exec/plugin-gen.h"
 
-// Avoid depedendencies on translate.c (pcc.cursor is always valid when we raise
-// an exception here):
-#define gen_cheri_update_cpu_pc(pc)
 #include "cheri-translate-utils-base.h"
 
 /* Pairs with tcg_clear_temp_count.

--- a/target/cheri-common/cheri-helper-common.h
+++ b/target/cheri-common/cheri-helper-common.h
@@ -46,7 +46,7 @@
 
 // PCC bounds checks:
 DEF_HELPER_1(raise_exception_pcc_perms, noreturn, env)
-DEF_HELPER_2(raise_exception_pcc_bounds, noreturn, env, i32)
+DEF_HELPER_3(raise_exception_pcc_bounds, noreturn, env, tl, i32)
 
 // Two-operand capability inspection
 DEF_HELPER_FLAGS_2(cgetaddr, TCG_CALL_NO_WG, tl, env, i32)

--- a/target/cheri-common/cheri-translate-utils-base.h
+++ b/target/cheri-common/cheri-translate-utils-base.h
@@ -1,0 +1,59 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2020 Alex Richardson
+ * All rights reserved.
+ *
+ * This software was developed by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#pragma once
+#include "tcg/tcg.h"
+#include "tcg/tcg-op.h"
+// Note: Due to cyclic dependencies we can only use DisasContextBase in this
+// file and must avoid anything defined in translate.c as it is also included
+// from accel/tcg/translator.c.
+
+#ifdef TARGET_CHERI
+static inline bool in_pcc_bounds(DisasContextBase *db, target_ulong addr)
+{
+    return addr >= db->pcc_base && addr < db->pcc_top;
+}
+
+// Raise a bounds violation exception on PCC
+static inline void gen_raise_pcc_violation(DisasContextBase *db, target_ulong addr,
+                                           uint32_t num_bytes)
+{
+    tcg_debug_assert(!in_pcc_bounds(db, addr));
+    gen_cheri_update_cpu_pc(db->pc_next); // Ensure correct PCC.cursor
+    TCGv_i32 tbytes = tcg_const_i32(num_bytes);
+    TCGv taddr = tcg_const_tl(addr);
+    gen_helper_raise_exception_pcc_bounds(cpu_env, taddr, tbytes);
+    tcg_temp_free_i32(tbytes);
+    tcg_temp_free(taddr);
+}
+
+#endif // TARGET_CHERI

--- a/target/cheri-common/cheri-translate-utils.h
+++ b/target/cheri-common/cheri-translate-utils.h
@@ -96,6 +96,7 @@ static inline void gen_check_pcc_bounds_next_inst(DisasContext *ctx,
     tcg_debug_assert(ctx->base.pc_next >= ctx->base.pc_first);
     // XXX: __builtin_add_overflow() for end of address space?
     if (unlikely(ctx->base.pc_next + num_bytes > ctx->base.pcc_top)) {
+        cheri_tcg_prepare_for_unconditional_exception(&ctx->base);
         gen_raise_pcc_violation(&ctx->base, ctx->base.pc_next, num_bytes);
     }
 #endif
@@ -105,6 +106,7 @@ static inline void gen_check_branch_target(DisasContext *ctx, target_ulong addr)
 {
 #ifdef TARGET_CHERI
     if (unlikely(!in_pcc_bounds(&ctx->base, addr))) {
+        cheri_tcg_prepare_for_unconditional_exception(&ctx->base);
         gen_raise_pcc_violation(&ctx->base, addr, 0);
     }
 #endif

--- a/target/cheri-common/cheri-translate-utils.h
+++ b/target/cheri-common/cheri-translate-utils.h
@@ -85,9 +85,15 @@ static inline void generate_get_ddc_checked_gpr_plus_offset(
 
 #endif // TARGET_CHERI
 
-static inline void gen_check_pcc_bounds(DisasContext* ctx, uint32_t num_bytes)
+static inline void gen_check_pcc_bounds_next_inst(DisasContext *ctx,
+                                                  uint32_t num_bytes)
 {
 #ifdef TARGET_CHERI
+    // Note: PC can only be incremented since a branch exits the TB, so checking
+    // for pc_next < pcc.base should not be needed.
+    // Add a debug assertion in case this assumption no longer holds in the
+    // future.
+    tcg_debug_assert(ctx->base.pc_next >= ctx->base.pc_first);
     // XXX: __builtin_add_overflow() for end of address space?
     if (unlikely(ctx->base.pc_next + num_bytes > ctx->base.pcc_top)) {
         // Raise a bounds violation exception

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -1271,12 +1271,21 @@ void store_cap_to_memory(CPUArchState *env, uint32_t cs,
 }
 #endif
 
+QEMU_NORETURN static inline void raise_pcc_fault(CPUArchState *env,
+                                                 CheriCapExcCause cause)
+{
+    cheri_debug_assert(pc_is_current(env));
+    // Note: we set pc=0 since PC will have been saved prior to calling the
+    // helper and we don't need to recompute it from the generated code.
+    raise_cheri_exception_impl(env, cause, CHERI_EXC_REGNUM_PCC,
+        /*instavail=*/true, 0);
+}
+
 void CHERI_HELPER_IMPL(raise_exception_pcc_perms(CPUArchState *env))
 {
     // On translation block entry we check that PCC is tagged and unsealed,
     // has the required permissions and is within bounds
     // The running of the end check is performed in the translator
-    cheri_debug_assert(pc_is_current(env));
     const cap_register_t *pcc = cheri_get_current_pcc(env);
     CheriCapExcCause cause;
     if (!pcc->cr_tag) {
@@ -1291,23 +1300,20 @@ void CHERI_HELPER_IMPL(raise_exception_pcc_perms(CPUArchState *env))
                      __func__, PRINT_CAP_ARGS(pcc));
         tcg_abort();
     }
-    // Note: we set pc=0 since PC will have been saved prior to calling the
-    // helper and we don't need to recompute it from the generated code.
-    raise_cheri_exception_impl(env, cause, CHERI_EXC_REGNUM_PCC,
-                               /*instavail=*/true, 0);
+    raise_pcc_fault(env, cause);
 }
 
 void CHERI_HELPER_IMPL(raise_exception_pcc_bounds(CPUArchState *env,
+                                                  target_ulong addr,
                                                   uint32_t num_bytes))
 {
-    // On translation block entry we check that PCC is tagged and unsealed,
-    // has the required permissions and is within bounds
-    // The running of the end check is performed in the translator
-    cheri_debug_assert(pc_is_current(env));
+    // This helper is called either when ifetch runs off the end of pcc or when
+    // a branch (e.g. fixed offset relative branchor a jr/jalr instruction)
+    // would result in an out-of-bounds pcc value.
+    // It is useful to trap on branch rather than ifetch since it greatly
+    // improves the debugging experience (exception pc points somewhere
+    // helpful).
     cheri_debug_assert(
-        !cap_is_in_bounds(cheri_get_current_pcc(env), PC_ADDR(env), num_bytes));
-    // Note: we set pc=0 since PC will have been saved prior to calling the
-    // helper and we don't need to recompute it from the generated code.
-    raise_cheri_exception_impl(env, CapEx_LengthViolation, CHERI_EXC_REGNUM_PCC,
-                               /*instavail=*/true, 0);
+        !cap_is_in_bounds(cheri_get_current_pcc(env), addr, num_bytes));
+    raise_pcc_fault(env, CapEx_LengthViolation);
 }

--- a/target/mips/helper.h
+++ b/target/mips/helper.h
@@ -201,7 +201,6 @@ DEF_HELPER_2(magic_library_function, void, env, tl)
 #if defined(TARGET_CHERI)
 #include "cheri-helper-common.h"
 DEF_HELPER_2(mtc2_dumpcstate, void, env, tl)
-DEF_HELPER_1(ccheck_btarget, void, env)
 DEF_HELPER_1(copy_cap_btarget_to_pcc, void, env)
 DEF_HELPER_3(ccheck_store, cap_checked_ptr, env, tl, i32)
 DEF_HELPER_3(ccheck_load, cap_checked_ptr, env, tl, i32)

--- a/target/mips/op_helper_cheri.c
+++ b/target/mips/op_helper_cheri.c
@@ -1146,15 +1146,6 @@ void store_cap_to_memory(CPUArchState *env, uint32_t cs, target_ulong vaddr,
 
 #endif /* ! CHERI_MAGIC128 */
 
-void CHERI_HELPER_IMPL(ccheck_btarget(CPUArchState *env))
-{
-    // Check whether the branch target is within $pcc and if not raise an exception
-    // qemu_log_mask(CPU_LOG_INSTR, "%s: env->pc=0x" TARGET_FMT_lx " hflags=0x%x, btarget=0x" TARGET_FMT_lx "\n",
-    //    __func__, PC_ADDR(env), env->hflags, env->btarget);
-    check_cap(env, cheri_get_recent_pcc(env), CAP_PERM_EXECUTE, env->btarget,
-              0xff, 4, /*instavail=*/false, GETPC());
-}
-
 void CHERI_HELPER_IMPL(copy_cap_btarget_to_pcc(CPUArchState *env))
 {
 #ifdef QEMU_USE_COMPRESSED_CHERI_CAPS

--- a/target/mips/translate.c
+++ b/target/mips/translate.c
@@ -2980,7 +2980,6 @@ static inline void gen_save_pc(target_ulong pc)
     tcg_gen_movi_tl(_pc_is_current, 1); // PC has been updated.
 #endif
 }
-#define gen_cheri_update_cpu_pc gen_save_pc
 #include "cheri-translate-utils.h"
 
 static inline void save_cpu_state(DisasContext *ctx, int do_save_pc)
@@ -3050,6 +3049,15 @@ static inline void generate_exception(DisasContext *ctx, int excp)
 static inline void generate_exception_end(DisasContext *ctx, int excp)
 {
     generate_exception_err(ctx, excp, 0);
+}
+
+void cheri_tcg_save_pc(DisasContextBase *db) { gen_save_pc(db->pc_next); }
+// We have to save the current PC before setting DISAS_NORETURN (see
+// generate_exception_err())
+void cheri_tcg_prepare_for_unconditional_exception(DisasContextBase *db)
+{
+    cheri_tcg_save_pc(db);
+    db->is_jmp = DISAS_NORETURN;
 }
 
 /* Floating point register moves. */

--- a/target/mips/translate.c
+++ b/target/mips/translate.c
@@ -6501,10 +6501,7 @@ static void gen_compute_branch(DisasContext *ctx, uint32_t opc,
     // Some debug assertions to ensure all branch cases are bounds checked
 #define SET_BTARGET_CHECKED(value) \
     do { tcg_debug_assert(!btarget_checked); btarget_checked = value; } while (false)
-#define GEN_CCHECK_BTARGET(cpu_env) \
-    do { SET_BTARGET_CHECKED(true); gen_helper_ccheck_btarget(cpu_env); } while (false)
 #else
-#define GEN_CCHECK_BTARGET(cpu_env)
 #define SET_BTARGET_CHECKED(value)
 #endif // defined(TARGET_CHERI)
 
@@ -6588,7 +6585,8 @@ static void gen_compute_branch(DisasContext *ctx, uint32_t opc,
         /* Add PCC.base to rs (jr/jalr is relative to PCC) */
         tcg_gen_addi_tl(btarget, btarget, ctx->base.pcc_base);
 #endif /* TARGET_CHERI */
-        GEN_CCHECK_BTARGET(cpu_env);
+        gen_check_branch_target_dynamic(ctx, btarget);
+        SET_BTARGET_CHECKED(true);
         break;
     default:
         MIPS_INVAL("branch/jump");

--- a/target/mips/translate.c
+++ b/target/mips/translate.c
@@ -31770,13 +31770,6 @@ static void mips_tr_insn_start(DisasContextBase *dcbase, CPUState *cs)
     // use longjmp to jump out of the tb so it is quite difficult.
     mips_update_statcounters_icount(ctx); // Increment the current icount value
 
-#ifdef TARGET_CHERI
-    // Note: PC can only be incremented since a branch exits the TB, so checking
-    // for pc_next < pcc.base should not be needed.
-    // Add a debug assertion in case this assumption no longer holds in the
-    // future.
-    tcg_debug_assert(ctx->base.pc_next >= ctx->base.pc_first);
-#endif
 #ifdef CONFIG_MIPS_LOG_INSTR
     if (unlikely(ctx->base.log_instr)) {
         // Print changed state before advancing to the next instruction: GPR,
@@ -31817,7 +31810,7 @@ static void mips_tr_translate_insn(DisasContextBase *dcbase, CPUState *cs)
     int is_slot;
     // XXX: we don't support micromips, etc. so we can hardcode 4 bytes as the
     // instruction size (see assert below).
-    gen_check_pcc_bounds(ctx, 4);
+    gen_check_pcc_bounds_next_inst(ctx, 4);
     is_slot = ctx->hflags & MIPS_HFLAG_BMASK;
     if (ctx->insn_flags & ISA_NANOMIPS32) {
 #ifdef TARGET_CHERI

--- a/target/riscv/translate.c
+++ b/target/riscv/translate.c
@@ -298,9 +298,15 @@ static inline void _gen_set_gpr_const(DisasContext *ctx, int reg_num_dst,
 
 #define gen_set_gpr(reg_num_dst, t) _gen_set_gpr(ctx, reg_num_dst, t)
 #define gen_set_gpr_const(reg_num_dst, t) _gen_set_gpr_const(ctx, reg_num_dst, t)
-#define gen_cheri_update_cpu_pc gen_update_cpu_pc
 #include "cheri-translate-utils.h"
-
+void cheri_tcg_save_pc(DisasContextBase *db) { gen_update_cpu_pc(db->pc_next); }
+// We have to call gen_update_cpu_pc() before setting DISAS_NORETURN (see
+// generate_exception())
+void cheri_tcg_prepare_for_unconditional_exception(DisasContextBase *db)
+{
+    cheri_tcg_save_pc(db);
+    db->is_jmp = DISAS_NORETURN;
+}
 
 static void gen_mulhsu(TCGv ret, TCGv arg1, TCGv arg2)
 {

--- a/target/riscv/translate.c
+++ b/target/riscv/translate.c
@@ -919,7 +919,7 @@ static void decode_opc(CPURISCVState *env, DisasContext *ctx)
     /* check for compressed insn */
     if (extract16(opcode, 0, 2) != 3) {
         gen_rvfi_dii_set_field_const(insn, opcode);
-        gen_check_pcc_bounds(ctx, 2);
+        gen_check_pcc_bounds_next_inst(ctx, 2);
         if (!has_ext(ctx, RVC)) {
             gen_exception_illegal(ctx);
         } else {
@@ -941,7 +941,7 @@ static void decode_opc(CPURISCVState *env, DisasContext *ctx)
 #endif
         uint32_t opcode32 = opcode;
         opcode32 = deposit32(opcode32, 16, 16, next_16);
-        gen_check_pcc_bounds(ctx, 4);
+        gen_check_pcc_bounds_next_inst(ctx, 4);
         ctx->pc_succ_insn = ctx->base.pc_next + 4;
         gen_rvfi_dii_set_field_const(insn, opcode32);
         if (!decode_insn32(ctx, opcode32)) {


### PR DESCRIPTION
Overall this reduces the kernel startup from:
```
       1197.128333      task-clock (msec)         #    0.577 CPUs utilized            ( +-  0.92% )
               431      context-switches          #    0.360 K/sec                    ( +-  0.98% )
                 2      cpu-migrations            #    0.002 K/sec                    ( +- 44.44% )
             7,266      page-faults               #    0.006 M/sec                    ( +-  0.77% )
     4,817,409,965      cycles                    #    4.024 GHz                      ( +-  0.30% )  (50.01%)
    13,510,506,710      instructions              #    2.80  insn per cycle           ( +-  0.45% )  (62.61%)
     2,365,632,069      branches                  # 1976.089 M/sec                    ( +-  0.38% )  (62.59%)
         7,593,704      branch-misses             #    0.32% of all branches          ( +-  1.42% )  (62.60%)
     3,485,048,757      L1-dcache-loads           # 2911.174 M/sec                    ( +-  0.35% )  (62.67%)
        29,513,912      L1-dcache-load-misses     #    0.85% of all L1-dcache hits    ( +-  1.01% )  (62.42%)
         2,903,959      LLC-loads                 #    2.426 M/sec                    ( +-  2.46% )  (49.84%)
           319,993      LLC-load-misses           #   11.02% of all LL-cache hits     ( +-  3.77% )  (49.86%)

       2.075448587 seconds time elapsed                                          ( +-  0.79% )
```
to
```
       1124.005361      task-clock (msec)         #    0.554 CPUs utilized            ( +-  0.56% )
               412      context-switches          #    0.367 K/sec                    ( +-  0.99% )
                 5      cpu-migrations            #    0.004 K/sec                    ( +- 23.75% )
             7,220      page-faults               #    0.006 M/sec                    ( +-  0.61% )
     4,479,150,899      cycles                    #    3.985 GHz                      ( +-  0.17% )  (49.70%)
    12,678,267,275      instructions              #    2.83  insn per cycle           ( +-  0.27% )  (62.33%)
     2,207,617,055      branches                  # 1964.063 M/sec                    ( +-  0.18% )  (62.48%)
         7,085,827      branch-misses             #    0.32% of all branches          ( +-  1.05% )  (62.59%)
     3,211,821,304      L1-dcache-loads           # 2857.479 M/sec                    ( +-  0.18% )  (62.83%)
        27,558,280      L1-dcache-load-misses     #    0.86% of all L1-dcache hits    ( +-  0.85% )  (62.73%)
         2,602,280      LLC-loads                 #    2.315 M/sec                    ( +-  2.30% )  (49.91%)
           334,191      LLC-load-misses           #   12.84% of all LL-cache hits     ( +-  2.60% )  (49.76%)

       2.029553619 seconds time elapsed                                          ( +-  0.45% )
```

After this change the remaining hot functions are as follows:
```
Samples: 4K of event 'cycles:ppp', Event count (approx.): 4513576048
  Children      Self  Command          Shared Object                      Symbol
+   13.50%    13.47%  qemu-system-che  qemu-system-cheri128.btarget_omit  [.] cheri_tag_invalidate
+   12.27%     0.00%  qemu-system-che  [unknown]                          [.] 0x0000000000000001
+    9.72%     0.03%  qemu-system-che  [unknown]                          [.] 0000000000000000
+    8.48%     8.45%  qemu-system-che  qemu-system-cheri128.btarget_omit  [.] check_ddc
+    7.26%     7.26%  qemu-system-che  qemu-system-cheri128.btarget_omit  [.] address_space_translate_internal
+    6.30%     6.24%  qemu-system-che  qemu-system-cheri128.btarget_omit  [.] liveness_pass_1
+    6.29%     6.29%  qemu-system-che  qemu-system-cheri128.btarget_omit  [.] get_physical_address
+    5.94%     0.61%  qemu-system-che  libc-2.27.so                       [.] __clock_gettime
+    5.49%     1.77%  qemu-system-che  [vdso]                             [.] __vdso_clock_gettime
+    3.89%     3.89%  qemu-system-che  qemu-system-cheri128.btarget_omit  [.] cpu_exec
+    3.70%     3.70%  qemu-system-che  qemu-system-cheri128.btarget_omit  [.] r4k_map_address
+    3.21%     3.19%  qemu-system-che  qemu-system-cheri128.btarget_omit  [.] tcg_optimize
     2.92%     2.92%  qemu-system-che  [vdso]                             [.] 0x0000000000000977
+    2.17%     2.10%  qemu-system-che  qemu-system-cheri128.btarget_omit  [.] tb_gen_code
+    2.16%     2.12%  qemu-system-che  qemu-system-cheri128.btarget_omit  [.] helper_lookup_tb_ptr
+    1.86%     1.86%  qemu-system-che  qemu-system-cheri128.btarget_omit  [.] tb_find
+    1.71%     1.24%  qemu-system-che  libc-2.27.so                       [.] __memmove_avx_unaligned_erms
+    1.64%     1.62%  qemu-system-che  qemu-system-cheri128.btarget_omit  [.] tcg_reg_alloc_op
+    1.55%     1.55%  qemu-system-che  qemu-system-cheri128.btarget_omit  [.] helper_ddc_check_load
+    1.21%     1.21%  qemu-system-che  qemu-system-cheri128.btarget_omit  [.] qemu_clock_get_ns
```

The easiest win now is probably caching tag address lookups and saving DDC base+top+tag in DisasContext and retranslating if it changes.