### PR TITLE
Fix checks for ifetch PCC wraparound

### DIFF
--- a/target/cheri-common/cheri-translate-utils-base.h
+++ b/target/cheri-common/cheri-translate-utils-base.h
@@ -43,6 +43,9 @@ void cheri_tcg_save_pc(DisasContextBase *db);
 #ifdef TARGET_CHERI
 static inline bool in_pcc_bounds(DisasContextBase *db, target_ulong addr)
 {
+    if ((db->cheri_flags & TB_FLAG_PCC_FULL_AS) == TB_FLAG_PCC_FULL_AS) {
+        return true; // PCC spans the full address space
+    }
     return addr >= db->pcc_base && addr < db->pcc_top;
 }
 

--- a/target/cheri-common/cheri-translate-utils.h
+++ b/target/cheri-common/cheri-translate-utils.h
@@ -264,7 +264,7 @@ static inline void gen_check_branch_target_dynamic(DisasContext *ctx, TCGv addr)
     //        call    raise_bounds_violation
     // Note: JR/JALR will often be used in hybrid/non-CHERI cases, so we can
     // skip the less than check if pcc.base is zero and top is MAX:
-    if (likely(have_cheri_tb_flags(ctx, TB_FLAG_PCC_FULL_AS))) {
+    if (have_cheri_tb_flags(ctx, TB_FLAG_PCC_FULL_AS)) {
         return; // PCC spans the full address space, no need to check
     }
 
@@ -272,7 +272,7 @@ static inline void gen_check_branch_target_dynamic(DisasContext *ctx, TCGv addr)
     TCGLabel *bounds_violation = gen_new_label();
     // We can skip the check of pcc.base if it is zero (common case in
     // hybrid/non-CHERI  mode).
-    if (unlikely(ctx->base.pcc_base > 0)) {
+    if (ctx->base.pcc_base > 0) {
         tcg_gen_brcondi_tl(TCG_COND_LTU, addr, ctx->base.pcc_base,
                            bounds_violation);
     }

--- a/target/cheri-common/cheri_defs.h
+++ b/target/cheri-common/cheri_defs.h
@@ -139,5 +139,10 @@ typedef enum CheriTbFlags {
      */
     TB_FLAG_CHERI_DDC_NO_INTERPOSE =
         (TB_FLAG_CHERI_DDC_BASE_ZERO | TB_FLAG_CHERI_DDC_CURSOR_ZERO),
+    /*
+     * PCC spans the full adddress space and has base zero. This means we do
+     * not need to perform bounds checks or subtract/add PCC.base
+     */
+    TB_FLAG_PCC_FULL_AS = (1 << 7)
 } CheriTbFlags;
 #endif // TARGET_CHERI

--- a/target/cheri-common/cpu_cheri.h
+++ b/target/cheri-common/cpu_cheri.h
@@ -137,6 +137,9 @@ static inline void cheri_cpu_get_tb_cpu_state(const cap_register_t *pcc,
     *cs_top = cap_get_top(pcc);
     *cheri_flags |=
         cheri_cap_perms_valid_for_exec(pcc) ? TB_FLAG_CHERI_PCC_VALID : 0;
+    if (cs_base == 0 && cap_get_top65(pcc) == CAP_MAX_TOP) {
+        *cheri_flags |= TB_FLAG_PCC_FULL_AS;
+    }
     if (ddc->cr_tag && cap_is_unsealed(ddc)) {
         if (cap_has_perms(ddc, CAP_PERM_LOAD))
             *cheri_flags |= TB_FLAG_CHERI_DDC_READABLE;


### PR DESCRIPTION
Since github doesn't allow pull request deps I'm just pushing all the changes. Please ignore everything except for the last commit.

----

Add TB_FLAG_PCC_FULL_AS to indicate that PCC spans the full address space

If this flag is set we can skip PCC bounds comparisons and correctly permit
instructions that wrap around the address space. While this is add odd
thing to permit, some code that does not enable CHERI may depend on it so
we should not break it if a user unaware of CHERI has not enabled any of
the features.

It is also slightly faster to use a bit test compared to address comparisons:

Before:
 Performance counter stats for '/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-cheri128.pcc_full_as_check.pre -M malta -kernel /local/scratch/alr48/cheri/output/kernel-mips-hybrid128.CHERI128_MALTA64_MFS_ROOT -m 2048 -nographic -append cheribsd.kernel_startup_benchmark=1' (10 runs):

        799.264214      task-clock (msec)         #    0.464 CPUs utilized            ( +-  0.28% )
               327      context-switches          #    0.409 K/sec                    ( +-  0.89% )
                 4      cpu-migrations            #    0.005 K/sec                    ( +- 21.99% )
             7,224      page-faults               #    0.009 M/sec                    ( +-  0.75% )
     3,224,834,528      cycles                    #    4.035 GHz                      ( +-  0.24% )  (49.55%)
     8,522,069,056      instructions              #    2.64  insn per cycle           ( +-  0.14% )  (62.18%)
     1,426,356,839      branches                  # 1784.587 M/sec                    ( +-  0.21% )  (62.41%)
         5,619,693      branch-misses             #    0.39% of all branches          ( +-  0.91% )  (62.56%)
     2,163,469,900      L1-dcache-loads           # 2706.827 M/sec                    ( +-  0.24% )  (62.63%)
        24,732,060      L1-dcache-load-misses     #    1.14% of all L1-dcache hits    ( +-  0.95% )  (63.01%)
         2,337,471      LLC-loads                 #    2.925 M/sec                    ( +-  1.18% )  (49.97%)
           348,633      LLC-load-misses           #   14.91% of all LL-cache hits     ( +-  2.93% )  (49.86%)

       1.721071293 seconds time elapsed                                          ( +-  0.58% )

After:
 Performance counter stats for '/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-cheri128.pcc_full_as_check -M malta -kernel /local/scratch/alr48/cheri/output/kernel-mips-hybrid128.CHERI128_MALTA64_MFS_ROOT -m 2048 -nographic -append cheribsd.kernel_startup_benchmark=1' (10 runs):

        789.799776      task-clock (msec)         #    0.465 CPUs utilized            ( +-  0.19% )
               322      context-switches          #    0.407 K/sec                    ( +-  0.79% )
                 4      cpu-migrations            #    0.005 K/sec                    ( +- 16.14% )
             7,173      page-faults               #    0.009 M/sec                    ( +-  0.71% )
     3,184,737,588      cycles                    #    4.032 GHz                      ( +-  0.11% )  (49.41%)
     8,522,670,588      instructions              #    2.68  insn per cycle           ( +-  0.43% )  (62.15%)
     1,431,723,644      branches                  # 1812.768 M/sec                    ( +-  0.28% )  (62.43%)
         5,459,980      branch-misses             #    0.38% of all branches          ( +-  0.55% )  (62.88%)
     2,131,540,406      L1-dcache-loads           # 2698.836 M/sec                    ( +-  0.27% )  (63.04%)
        26,869,335      L1-dcache-load-misses     #    1.26% of all L1-dcache hits    ( +-  1.11% )  (63.09%)
         2,425,252      LLC-loads                 #    3.071 M/sec                    ( +-  1.77% )  (49.78%)
           339,552      LLC-load-misses           #   14.00% of all LL-cache hits     ( +-  3.68% )  (49.37%)

       1.699457956 seconds time elapsed                                          ( +-  0.04% )