### PR TITLE
Raise an MCHECK exception on duplicate TLB entry insertion.

### DIFF
--- a/target/mips/internal.h
+++ b/target/mips/internal.h
@@ -161,6 +161,7 @@ void r4k_helper_tlbr(CPUMIPSState *env);
 void r4k_helper_tlbinv(CPUMIPSState *env);
 void r4k_helper_tlbinvf(CPUMIPSState *env);
 void r4k_invalidate_tlb(CPUMIPSState *env, int idx, int use_extra);
+bool r4k_lookup_tlb(CPUMIPSState *env, int *matching, bool use_extra);
 
 void mips_cpu_do_transaction_failed(CPUState *cs, hwaddr physaddr,
                                     vaddr addr, unsigned size,


### PR DESCRIPTION
When a tlbwi or tlbwr attempts to add an entry with an EntryHi value that
matches another entry already in the TLB, raise an MCHECK exception.
This is an optional feature in the Mips64 specification.