### PR TITLE
mips_cpu_synchronize_from_tb does not need to clear CP0_LLAddr

### DIFF
--- a/target/mips/cpu.c
+++ b/target/mips/cpu.c
@@ -217,7 +217,6 @@ static void mips_cpu_synchronize_from_tb(CPUState *cs, TranslationBlock *tb)
      *
      * See also target/mips/op_helper:/helper_eret
      */
-    env->CP0_LLAddr = 1;
     env->lladdr = 1;
 }
 


### PR DESCRIPTION
Setting it to 1 breaks a test that expects the architecturally visible
CP0 LLAddr register to be zero one reset.
For the purposes of breaking ll/sc, we only need to invalidate the virtual
lladdr value so remove the assignment to env->CP0_LLAddr.