### PR TITLE
[UPSTREAM] riscv MMU: zero reserved pte bits in ppn 

### DIFF
--- a/target/riscv/cpu_helper.c
+++ b/target/riscv/cpu_helper.c
@@ -584,7 +584,16 @@ restart:
             return TRANSLATE_FAIL;
         }
 
+#if !defined(TARGET_RISCV32)
+        /*
+         * The top ten bits of the PTE are reserved.  While there may
+         * eventually be a RISCV system with more than 44 bits of ppn (that is,
+         * a 56-bit physical address space, or 64 PiB), we aren't one, yet.
+         */
+        hwaddr ppn = (pte & ~0xFFC0000000000000ULL) >> PTE_PPN_SHIFT;
+#else
         hwaddr ppn = pte >> PTE_PPN_SHIFT;
+#endif
 
         if (!(pte & PTE_V)) {
             /* Invalid PTE */


### PR DESCRIPTION
CHERI is going to use (some of) these reserved PTE bits for its own
ends, and they shouldn't end up in the physical page number.  Due to the
way the shifts work out (down by 10 from PTE_PPN_SHIFT, up by 12 from
PGSHIFT), the top two bits are implicitly discarded, but the rest were
not.