### PR TITLE
cheri-riscv: csetequalexact

### DIFF
--- a/disas/riscv.c
+++ b/disas/riscv.c
@@ -535,6 +535,7 @@ typedef enum {
     rv_op_ccopytype,
     rv_op_ccseal,
     rv_op_ctestsubset,
+    rv_op_cseqx,
 
     // FP loads/store
     rv_op_cflw,
@@ -1264,6 +1265,7 @@ const rv_opcode_data opcode_data[] = {
     [rv_op_ccopytype] = { "ccopytype", rv_codec_r, rv_fmt_cd_cs1_cs2, NULL, 0, 0, 0 },
     [rv_op_ccseal] = { "ccseal", rv_codec_r, rv_fmt_cd_cs1_cs2, NULL, 0, 0, 0 },
     [rv_op_ctestsubset] = { "ctestsubset", rv_codec_r, rv_fmt_rd_cs1_cs2, NULL, 0, 0, 0 },
+    [rv_op_cseqx] = { "cseqx", rv_codec_r, rv_fmt_rd_cs1_cs2, NULL, 0, 0, 0 },
 
     // FP load store
     [rv_op_cflw] = { "cflw", rv_codec_i, rv_fmt_frd_offset_cs1, NULL, 0, 0, 0 },
@@ -1531,6 +1533,7 @@ static rv_opcode decode_cheri_inst(rv_inst inst) {
     CHERI_THREEOP_CASE(ccopytype,   0011110,  ..... ..... 000 ..... 1011011 @r)
     CHERI_THREEOP_CASE(ccseal,      0011111,  ..... ..... 000 ..... 1011011 @r)
     CHERI_THREEOP_CASE(ctestsubset, 0100000,  ..... ..... 000 ..... 1011011 @r)
+    CHERI_THREEOP_CASE(cseqx,       0100001,  ..... ..... 000 ..... 1011011 @r)
     // 1111011 unused
     // TODO: 1111100 Used for Stores (see below)
     // TODO: 1111101 Used for Loads (see below)

--- a/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap_common.h
+++ b/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap_common.h
@@ -101,16 +101,24 @@ struct _cc_N(cap) {
     inline uint32_t permissions() const { return cr_perms; }
     inline uint32_t type() const { return cr_otype; }
     inline bool is_sealed() const { return cr_otype != _CC_N(OTYPE_UNSEALED); }
-    inline bool operator==(const _cc_N(cap) & other) const {
-        return _cr_cursor == other._cr_cursor && cr_base == other.cr_base && _cr_top == other._cr_top &&
-               cr_perms == other.cr_perms && cr_uperms == other.cr_uperms && cr_otype == other.cr_otype &&
-               cr_ebt == other.cr_ebt && cr_flags == other.cr_flags && cr_reserved == other.cr_reserved &&
-               cr_tag == other.cr_tag;
-    }
+    inline bool operator==(const _cc_N(cap) & other) const;
 #endif
 };
 typedef struct _cc_N(cap) _cc_N(cap_t);
 #define _cc_cap_t _cc_N(cap_t)
+
+static inline bool _cc_N(exactly_equal)(struct _cc_N(cap) const *a, struct _cc_N(cap) const *b) {
+  return a->cr_tag == b->cr_tag &&
+         a->_cr_cursor == b->_cr_cursor &&
+         a->cr_base == b->cr_base &&
+         a->_cr_top == b->_cr_top &&
+         a->cr_perms == b->cr_perms &&
+         a->cr_uperms == b->cr_uperms &&
+         a->cr_otype == b->cr_otype &&
+         a->cr_ebt == b->cr_ebt &&
+         a->cr_flags == b->cr_flags &&
+         a->cr_reserved == b->cr_reserved;
+}
 
 /* Returns the index of the most significant bit set in x */
 static inline uint32_t _cc_N(idx_MSNZ)(uint64_t x) {
@@ -760,6 +768,10 @@ static inline _cc_addr_t _cc_N(get_representable_length)(_cc_addr_t req_length) 
 /// Provide a C++ class with the same function names
 /// to simplify writing code that handles both 128 and 64-bit capabilities
 #ifdef __cplusplus
+inline bool _cc_N(cap)::operator==(const _cc_N(cap) & other) const {
+    return _cc_N(exactly_equal)(this, other);
+}
+
 class _CC_CONCAT(CompressedCap, CC_BITS) {
 public:
     using length_t = _cc_length_t;

--- a/target/cheri-common/cheri-helper-common.h
+++ b/target/cheri-common/cheri-helper-common.h
@@ -96,6 +96,7 @@ DEF_HELPER_4(csetoffset, void, env, i32, i32, tl)
 // Three operands (int cap cap)
 DEF_HELPER_FLAGS_3(csub, TCG_CALL_NO_WG, tl, env, i32, i32)
 DEF_HELPER_FLAGS_3(ctestsubset, TCG_CALL_NO_WG, tl, env, i32, i32)
+DEF_HELPER_FLAGS_3(cseqx, TCG_CALL_NO_WG, tl, env, i32, i32)
 DEF_HELPER_FLAGS_3(ctoptr, TCG_CALL_NO_WG, tl, env, i32, i32)
 
 // Loads+Stores

--- a/target/cheri-common/cheri_utils.h
+++ b/target/cheri-common/cheri_utils.h
@@ -107,6 +107,15 @@ static inline int64_t cap_get_otype(const cap_register_t* c) {
     return result < CAP_LAST_NONRESERVED_OTYPE ? result : result - CAP_MAX_REPRESENTABLE_OTYPE - 1;
 }
 
+static inline bool cap_exactly_equal(const cap_register_t *cbp, const cap_register_t *ctp)
+{
+#ifdef CHERI_128
+    return cc128_exactly_equal(cbp, ctp);
+#else
+    return cc256_exactly_equal(cbp, ctp);
+#endif
+}
+
 static inline bool cap_is_sealed_with_type(const cap_register_t* c) {
     // TODO: how should we treat the other reserved types? as sealed?
     // TODO: what about untagged capabilities with out-of-range otypes?

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -886,15 +886,7 @@ target_ulong CHERI_HELPER_IMPL(cseqx(CPUArchState *env, uint32_t cb,
     const cap_register_t *cbp = get_readonly_capreg(env, cb);
     const cap_register_t *ctp = get_readonly_capreg(env, ct);
 
-    return cbp->cr_tag           == ctp->cr_tag           &&
-           cap_get_cursor  (cbp) == cap_get_cursor  (ctp) &&
-           cap_get_base    (cbp) == cap_get_base    (ctp) &&
-           cap_get_length65(cbp) == cap_get_length65(ctp) &&
-           cap_get_otype   (cbp) == cap_get_otype   (ctp) &&
-           cbp->cr_perms         == ctp->cr_perms         &&
-           cbp->cr_uperms        == ctp->cr_uperms        &&
-           cbp->cr_flags         == ctp->cr_flags         &&
-           cbp->cr_reserved      == ctp->cr_reserved;
+    return cap_exactly_equal(cbp, ctp);
 }
 
 target_ulong CHERI_HELPER_IMPL(ctoptr(CPUArchState *env, uint32_t cb,

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -880,6 +880,23 @@ target_ulong CHERI_HELPER_IMPL(ctestsubset(CPUArchState *env, uint32_t cb,
     return (target_ulong)is_subset;
 }
 
+target_ulong CHERI_HELPER_IMPL(cseqx(CPUArchState *env, uint32_t cb,
+                                     uint32_t ct))
+{
+    const cap_register_t *cbp = get_readonly_capreg(env, cb);
+    const cap_register_t *ctp = get_readonly_capreg(env, ct);
+
+    return cbp->cr_tag           == ctp->cr_tag           &&
+           cap_get_cursor  (cbp) == cap_get_cursor  (ctp) &&
+           cap_get_base    (cbp) == cap_get_base    (ctp) &&
+           cap_get_length65(cbp) == cap_get_length65(ctp) &&
+           cap_get_otype   (cbp) == cap_get_otype   (ctp) &&
+           cbp->cr_perms         == ctp->cr_perms         &&
+           cbp->cr_uperms        == ctp->cr_uperms        &&
+           cbp->cr_flags         == ctp->cr_flags         &&
+           cbp->cr_reserved      == ctp->cr_reserved;
+}
+
 target_ulong CHERI_HELPER_IMPL(ctoptr(CPUArchState *env, uint32_t cb,
                                       uint32_t ct))
 {

--- a/target/mips/helper.h
+++ b/target/mips/helper.h
@@ -238,7 +238,6 @@ DEF_HELPER_3(clt, tl, env, i32, i32)
 DEF_HELPER_3(cle, tl, env, i32, i32)
 DEF_HELPER_3(cltu, tl, env, i32, i32)
 DEF_HELPER_3(cleu, tl, env, i32, i32)
-DEF_HELPER_3(cnexeq, tl, env, i32, i32)
 DEF_HELPER_3(cgetandaddr, tl, env, i32, tl)
 
 DEF_HELPER_3(cloadlinked, cap_checked_ptr, env, i32, i32)

--- a/target/mips/helper.h
+++ b/target/mips/helper.h
@@ -238,7 +238,6 @@ DEF_HELPER_3(clt, tl, env, i32, i32)
 DEF_HELPER_3(cle, tl, env, i32, i32)
 DEF_HELPER_3(cltu, tl, env, i32, i32)
 DEF_HELPER_3(cleu, tl, env, i32, i32)
-DEF_HELPER_3(cexeq, tl, env, i32, i32)
 DEF_HELPER_3(cnexeq, tl, env, i32, i32)
 DEF_HELPER_3(cgetandaddr, tl, env, i32, tl)
 

--- a/target/mips/op_helper_cheri.c
+++ b/target/mips/op_helper_cheri.c
@@ -133,8 +133,6 @@ static inline int align_of(int size, uint64_t addr)
     }
 }
 
-static bool cap_exactly_equal(const cap_register_t *cbp, const cap_register_t *ctp);
-
 static inline void update_ddc(CPUArchState *env, const cap_register_t* new_ddc) {
     if (!cap_exactly_equal(&env->active_tc.CHWR.DDC, new_ddc)) {
         qemu_log_instr_or_mask_msg(env, CPU_LOG_MMU,
@@ -632,37 +630,18 @@ target_ulong CHERI_HELPER_IMPL(cleu(CPUArchState *env, uint32_t cb, uint32_t ct)
     return (target_ulong)(cursor1_unsigned <= cursor2_unsigned);
 }
 
-static bool cap_exactly_equal(const cap_register_t *cbp, const cap_register_t *ctp) {
-  if (cbp->cr_tag != ctp->cr_tag) {
-    return false;
-  } else if (cbp->cr_base != ctp->cr_base) {
-    return false;
-  } else if (cbp->_cr_cursor != ctp->_cr_cursor) {
-    return false;
-  } else if (cbp->_cr_top != ctp->_cr_top) {
-    return false;
-  } else if (cbp->cr_otype != ctp->cr_otype) {
-    return false;
-  } else if (cbp->cr_perms != ctp->cr_perms) {
-    return false;
-  } else if (cbp->cr_flags != ctp->cr_flags) {
-      return false;
-  }
-  return true;
-}
-
 target_ulong CHERI_HELPER_IMPL(cexeq(CPUArchState *env, uint32_t cb, uint32_t ct))
 {
     const cap_register_t *cbp = get_readonly_capreg(env, cb);
     const cap_register_t *ctp = get_readonly_capreg(env, ct);
-    return (target_ulong)cap_exactly_equal(cbp, ctp);
+    return cap_exactly_equal(cbp, ctp);
 }
 
 target_ulong CHERI_HELPER_IMPL(cnexeq(CPUArchState *env, uint32_t cb, uint32_t ct))
 {
     const cap_register_t *cbp = get_readonly_capreg(env, cb);
     const cap_register_t *ctp = get_readonly_capreg(env, ct);
-    return (target_ulong) cap_exactly_equal(cbp, ctp) ? false : true;
+    return !cap_exactly_equal(cbp, ctp);
 }
 
 target_ulong CHERI_HELPER_IMPL(cgetandaddr(CPUArchState *env, uint32_t cb, target_ulong rt))

--- a/target/mips/op_helper_cheri.c
+++ b/target/mips/op_helper_cheri.c
@@ -630,13 +630,6 @@ target_ulong CHERI_HELPER_IMPL(cleu(CPUArchState *env, uint32_t cb, uint32_t ct)
     return (target_ulong)(cursor1_unsigned <= cursor2_unsigned);
 }
 
-target_ulong CHERI_HELPER_IMPL(cnexeq(CPUArchState *env, uint32_t cb, uint32_t ct))
-{
-    const cap_register_t *cbp = get_readonly_capreg(env, cb);
-    const cap_register_t *ctp = get_readonly_capreg(env, ct);
-    return !cap_exactly_equal(cbp, ctp);
-}
-
 target_ulong CHERI_HELPER_IMPL(cgetandaddr(CPUArchState *env, uint32_t cb, target_ulong rt))
 {
     target_ulong addr = get_capreg_cursor(env, cb);

--- a/target/mips/op_helper_cheri.c
+++ b/target/mips/op_helper_cheri.c
@@ -630,13 +630,6 @@ target_ulong CHERI_HELPER_IMPL(cleu(CPUArchState *env, uint32_t cb, uint32_t ct)
     return (target_ulong)(cursor1_unsigned <= cursor2_unsigned);
 }
 
-target_ulong CHERI_HELPER_IMPL(cexeq(CPUArchState *env, uint32_t cb, uint32_t ct))
-{
-    const cap_register_t *cbp = get_readonly_capreg(env, cb);
-    const cap_register_t *ctp = get_readonly_capreg(env, ct);
-    return cap_exactly_equal(cbp, ctp);
-}
-
 target_ulong CHERI_HELPER_IMPL(cnexeq(CPUArchState *env, uint32_t cb, uint32_t ct))
 {
     const cap_register_t *cbp = get_readonly_capreg(env, cb);

--- a/target/mips/translate_cheri.c
+++ b/target/mips/translate_cheri.c
@@ -823,7 +823,8 @@ static inline void generate_cnexeq(DisasContext *ctx, int32_t rd, int32_t cb,
     TCGv_i32 tct = tcg_const_i32(ct);
     TCGv t0 = tcg_temp_new();
 
-    gen_helper_cnexeq(t0, cpu_env, tcb, tct);
+    gen_helper_cseqx(t0, cpu_env, tcb, tct);
+    tcg_gen_xori_i64(t0, t0, 1);
     gen_store_gpr(t0, rd);
 
     tcg_temp_free(t0);

--- a/target/mips/translate_cheri.c
+++ b/target/mips/translate_cheri.c
@@ -808,7 +808,7 @@ static inline void generate_cexeq(DisasContext *ctx, int32_t rd, int32_t cb,
     TCGv_i32 tct = tcg_const_i32(ct);
     TCGv t0 = tcg_temp_new();
 
-    gen_helper_cexeq(t0, cpu_env, tcb, tct);
+    gen_helper_cseqx(t0, cpu_env, tcb, tct);
     gen_store_gpr(t0, rd);
 
     tcg_temp_free(t0);

--- a/target/riscv/insn32-cheri.decode
+++ b/target/riscv/insn32-cheri.decode
@@ -56,6 +56,7 @@ cbuildcap   0011101  ..... ..... 000 ..... 1011011 @r
 ccopytype   0011110  ..... ..... 000 ..... 1011011 @r
 ccseal      0011111  ..... ..... 000 ..... 1011011 @r
 ctestsubset 0100000  ..... ..... 000 ..... 1011011 @r
+cseqx       0100001  ..... ..... 000 ..... 1011011 @r
 # 1111011 unused
 # 1111100 Used for Stores (see below)
 # 1111101 Used for Loads (see below)

--- a/target/riscv/insn_trans/trans_cheri.inc.c
+++ b/target/riscv/insn_trans/trans_cheri.inc.c
@@ -216,6 +216,7 @@ TRANSLATE_CAP_CAP_INT(csetoffset)
 // Three operand (int cap cap)
 TRANSLATE_INT_CAP_CAP(csub)
 TRANSLATE_INT_CAP_CAP(ctestsubset)
+TRANSLATE_INT_CAP_CAP(cseqx)
 TRANSLATE_INT_CAP_CAP(ctoptr)
 
 // CIncOffsetImm/CSetBoundsImm:


### PR DESCRIPTION
Is there a better way than trying to enumerate all the fields of the decoded structure like this?