### PR TITLE
Optimizations for invalidate tags

### DIFF
--- a/accel/tcg/cputlb.c
+++ b/accel/tcg/cputlb.c
@@ -1213,6 +1213,17 @@ void tlb_set_page_with_attrs(CPUState *cpu, target_ulong vaddr,
      * vaddr we add back in io_readx()/io_writex()/get_page_addr_code().
      */
     desc->iotlb[index].addr = iotlb - vaddr_page;
+#ifdef TARGET_CHERI
+    // Cache the CHERI tag block. This massively speeds up running QEMU: before
+    // we added this optimization 10-25% of total runtime could be spent
+    // looking up tag blocks for a given virtual address.
+    if (section->mr->ram_block && (address & TLB_INVALID_MASK) == 0) {
+        desc->iotlb[index].tagmem =
+            cheri_tagmem_for_addr(section->mr->ram_block, xlat, size);
+    } else {
+        desc->iotlb[index].tagmem = NULL;
+    }
+#endif
     desc->iotlb[index].attrs = attrs;
 
     /* Now calculate the new entry */

--- a/accel/tcg/cputlb.c
+++ b/accel/tcg/cputlb.c
@@ -1217,12 +1217,8 @@ void tlb_set_page_with_attrs(CPUState *cpu, target_ulong vaddr,
     // Cache the CHERI tag block. This massively speeds up running QEMU: before
     // we added this optimization 10-25% of total runtime could be spent
     // looking up tag blocks for a given virtual address.
-    if (section->mr->ram_block && (address & TLB_INVALID_MASK) == 0) {
-        desc->iotlb[index].tagmem =
-            cheri_tagmem_for_addr(section->mr->ram_block, xlat, size);
-    } else {
-        desc->iotlb[index].tagmem = NULL;
-    }
+    desc->iotlb[index].tagmem =
+        cheri_tagmem_for_addr(section->mr->ram_block, xlat, size);
 #endif
     desc->iotlb[index].attrs = attrs;
 

--- a/accel/tcg/cputlb.c
+++ b/accel/tcg/cputlb.c
@@ -1636,8 +1636,12 @@ void *probe_access(CPUArchState *env, target_ulong addr, int size,
 
         /* Handle watchpoints.  */
         if (flags & TLB_WATCHPOINT) {
-            int wp_access = (access_type == MMU_DATA_STORE
-                             ? BP_MEM_WRITE : BP_MEM_READ);
+            bool is_write =
+#ifdef CONFIG_CHERI
+                access_type == MMU_DATA_CAP_STORE ||
+#endif
+                access_type == MMU_DATA_STORE;
+            int wp_access = is_write ? BP_MEM_WRITE : BP_MEM_READ;
             cpu_check_watchpoint(env_cpu(env), addr, size,
                                  iotlbentry->attrs, wp_access, retaddr);
         }

--- a/include/exec/cpu-defs.h
+++ b/include/exec/cpu-defs.h
@@ -150,6 +150,9 @@ typedef struct CPUIOTLBEntry {
      *     + the offset within the target MemoryRegion (otherwise)
      */
     hwaddr addr;
+#ifdef TARGET_CHERI
+    void *tagmem;
+#endif
     MemTxAttrs attrs;
 } CPUIOTLBEntry;
 

--- a/include/exec/log_instr.h
+++ b/include/exec/log_instr.h
@@ -137,7 +137,7 @@ void qemu_log_instr_flush_tcg(bool request_stop);
 
 /* Helper macro to check for instruction logging enabled */
 #define	qemu_log_instr_enabled(env)                                     \
-    (unlikely(qemu_log_instr_check_enabled((env))) ? true : false)
+    unlikely(qemu_log_instr_check_enabled((env)))
 
 /*
  * Check whether instruction tracing is enabled.

--- a/include/exec/ramblock.h
+++ b/include/exec/ramblock.h
@@ -66,4 +66,7 @@ struct RAMBlock {
     uint8_t clear_bmap_shift;
 };
 #endif
+
+void *cheri_tagmem_for_addr(RAMBlock *ram, ram_addr_t ram_offset, size_t size);
+
 #endif

--- a/target/cheri-common/cheri_tagmem.h
+++ b/target/cheri-common/cheri_tagmem.h
@@ -42,8 +42,20 @@ void cheri_tag_phys_invalidate(CPUArchState *env, RAMBlock *ram,
                                ram_addr_t offset, size_t len,
                                const target_ulong *vaddr);
 void cheri_tag_init(MemoryRegion* mr, uint64_t memory_size);
+/**
+ * Generic tag invalidation function to be called for a *single* data store:
+ * Note: this will currently invalidate at most two tags (as can happen
+ * for a unaligned store that crosses a CHERI_CAP_SIZE alignment boundary).
+ */
 void cheri_tag_invalidate(CPUArchState *env, target_ulong vaddr, int32_t size,
                           uintptr_t pc);
+/**
+ * Like cheri_tag_invalidate, but the address must be aligned and it will only
+ * invalidate a single tag (i.e. no unaligned accesses). A bit faster since it
+ * can avoid some branches.
+ */
+void cheri_tag_invalidate_aligned(CPUArchState *env, target_ulong vaddr,
+                                  uintptr_t pc);
 bool cheri_tag_get(CPUArchState *env, target_ulong vaddr, int reg,
                    hwaddr *ret_paddr, int *prot, uintptr_t pc);
 int cheri_tag_get_many(CPUArchState *env, target_ulong vaddr, int reg,

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -1240,7 +1240,7 @@ void store_cap_to_memory(CPUArchState *env, uint32_t cs,
         env->statcounters_cap_write_tagged++;
         cheri_tag_set(env, vaddr, cs, NULL, retpc);
     } else {
-        cheri_tag_invalidate(env, vaddr, CHERI_CAP_SIZE, retpc);
+        cheri_tag_invalidate_aligned(env, vaddr, retpc);
     }
     /* No TLB fault possible, should be safe to get a host pointer now */
     void* host = probe_write(env, vaddr, CHERI_CAP_SIZE, cpu_mmu_index(env, false), retpc);

--- a/target/mips/op_helper_cheri.c
+++ b/target/mips/op_helper_cheri.c
@@ -1001,7 +1001,7 @@ void store_cap_to_memory(CPUArchState *env, uint32_t cs, target_ulong vaddr,
         env->statcounters_cap_write_tagged++;
         cheri_tag_set(env, vaddr, cs, NULL, retpc);
     } else {
-        cheri_tag_invalidate(env, vaddr, CHERI_CAP_SIZE, retpc);
+        cheri_tag_invalidate_aligned(env, vaddr, retpc);
     }
     env->lladdr = 1;
 


### PR DESCRIPTION
RISCV boot benchmark before:
```
Performance counter stats for '/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.pre-invalidate -kernel /local/scratch/alr48/cheri/output/QEMU_BENCHMARK_RISCV64_HYBRID_KERNEL_PURECAP_MFS_ROOT -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -device virtio-net-device,netdev=net0 -netdev user,id=net0,ipv6=off -append init_path=/sbin/startup-benchmark.sh' (10 runs):

       4190.311225      task-clock (msec)         #    0.885 CPUs utilized            ( +-  0.65% )
             1,230      context-switches          #    0.294 K/sec                    ( +-  0.59% )
                 2      cpu-migrations            #    0.001 K/sec                    ( +- 34.93% )
             7,450      page-faults               #    0.002 M/sec                    ( +-  0.59% )
    13,984,847,818      cycles                    #    3.337 GHz                      ( +-  0.64% )  (30.71%)
    40,573,002,845      instructions              #    2.90  insn per cycle           ( +-  0.31% )  (38.52%)
     5,790,907,624      branches                  # 1381.976 M/sec                    ( +-  0.19% )  (38.49%)
        57,394,474      branch-misses             #    0.99% of all branches          ( +-  0.52% )  (38.58%)
    10,027,283,827      L1-dcache-loads           # 2392.969 M/sec                    ( +-  0.32% )  (38.70%)
       119,255,313      L1-dcache-load-misses     #    1.19% of all L1-dcache hits    ( +-  0.93% )  (38.62%)
         3,900,859      LLC-loads                 #    0.931 M/sec                    ( +-  2.04% )  (30.81%)
           706,916      LLC-load-misses           #   18.12% of all LL-cache hits     ( +-  9.14% )  (30.76%)
   <not supported>      L1-icache-loads
       342,126,170      L1-icache-load-misses                                         ( +-  0.56% )  (30.68%)
     9,987,088,685      dTLB-loads                # 2383.376 M/sec                    ( +-  0.83% )  (30.67%)
           209,036      dTLB-load-misses          #    0.00% of all dTLB cache hits   ( +-  3.75% )  (30.70%)
         3,621,255      iTLB-loads                #    0.864 M/sec                    ( +-  1.31% )  (30.66%)
         1,077,941      iTLB-load-misses          #   29.77% of all iTLB cache hits   ( +- 11.64% )  (30.62%)

       4.732444569 seconds time elapsed
```
After:
```
Performance counter stats for '/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri -kernel /local/scratch/alr48/cheri/output/QEMU_BENCHMARK_RISCV64_HYBRID_KERNEL_PURECAP_MFS_ROOT -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -device virtio-net-device,netdev=net0 -netdev user,id=net0,ipv6=off -append init_path=/sbin/startup-benchmark.sh' (10 runs):

After:
       3965.398176      task-clock (msec)         #    0.872 CPUs utilized            ( +-  0.41% )
             1,197      context-switches          #    0.302 K/sec                    ( +-  0.51% )
                 3      cpu-migrations            #    0.001 K/sec                    ( +- 20.83% )
             9,886      page-faults               #    0.002 M/sec                    ( +- 22.31% )
    12,975,511,287      cycles                    #    3.272 GHz                      ( +-  0.33% )  (30.96%)
    36,310,805,061      instructions              #    2.80  insn per cycle           ( +-  0.32% )  (38.68%)
     4,290,656,596      branches                  # 1082.024 M/sec                    ( +-  0.31% )  (38.60%)
        52,444,394      branch-misses             #    1.22% of all branches          ( +-  0.41% )  (38.54%)
     9,520,541,071      L1-dcache-loads           # 2400.904 M/sec                    ( +-  0.27% )  (38.44%)
       121,941,572      L1-dcache-load-misses     #    1.28% of all L1-dcache hits    ( +-  0.84% )  (38.36%)
         3,899,538      LLC-loads                 #    0.983 M/sec                    ( +-  6.62% )  (30.56%)
           904,366      LLC-load-misses           #   23.19% of all LL-cache hits     ( +- 21.52% )  (30.59%)
   <not supported>      L1-icache-loads
       338,198,675      L1-icache-load-misses                                         ( +-  0.74% )  (30.66%)
     9,544,742,562      dTLB-loads                # 2407.007 M/sec                    ( +-  0.30% )  (30.69%)
           220,078      dTLB-load-misses          #    0.00% of all dTLB cache hits   ( +- 11.12% )  (30.84%)
         4,496,137      iTLB-loads                #    1.134 M/sec                    ( +-  1.62% )  (30.87%)
           681,771      iTLB-load-misses          #   15.16% of all iTLB cache hits   ( +- 15.80% )  (30.90%)

       4.547806136 seconds time elapsed                                          ( +-  0.24% )
```