### PR TITLE
cbuildcap: Use the "bag of bits" when constructing

### DIFF
--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -444,7 +444,12 @@ void CHERI_HELPER_IMPL(cbuildcap(CPUArchState *env, uint32_t cd, uint32_t cb,
         result.cr_otype = CAP_OTYPE_UNSEALED;
         result.cr_tag = 1;
 
-        if (cap_is_sealed_entry(ctp)) {
+        /*
+         * cbuildcap is allowed to seal at any ambiently-available otype,
+         * subject to their construction conditions.  Otherwise, the result is
+         * unsealed.
+         */
+        if (cap_is_sealed_entry(ctp) && cap_has_perms(ctp, CAP_PERM_EXECUTE)) {
           cap_make_sealed_entry(&result);
         }
 

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -439,21 +439,15 @@ void CHERI_HELPER_IMPL(cbuildcap(CPUArchState *env, uint32_t cd, uint32_t cb,
     } else if ((ctp->cr_uperms & cbp->cr_uperms) != ctp->cr_uperms) {
         raise_cheri_exception(env, CapEx_UserDefViolation, cb_exc);
     } else {
-        /* XXXAM basic trivial implementation may not handle
-         * compressed capabilities fully, does not perform renormalization.
-         */
-        // Without the temporary cap_register_t we would copy cb into cd
-        // if cdp cd == ct (this was caught by testing cbuildcap $c3, $c1, $c3)
-        cap_register_t result = *cbp;
-        result.cr_base = ctp->cr_base;
-        result._cr_top = ctp->_cr_top;
-        result.cr_perms = ctp->cr_perms;
-        result.cr_uperms = ctp->cr_uperms;
-        result._cr_cursor = ctp->_cr_cursor;
-        if (cap_is_sealed_entry(ctp))
-            cap_make_sealed_entry(&result);
-        else
-            result.cr_otype = CAP_OTYPE_UNSEALED;
+        cap_register_t result = *ctp;
+
+        result.cr_otype = CAP_OTYPE_UNSEALED;
+        result.cr_tag = 1;
+
+        if (cap_is_sealed_entry(ctp)) {
+          cap_make_sealed_entry(&result);
+        }
+
         update_capreg(env, cd, &result);
     }
 }


### PR DESCRIPTION
This way we're sure we won't miss any of the state in the decoded bag of bits,
though we might allow construction of non-canonical capabilities.  I suspect
it's fine.