### PR TITLE
Implement a new mode for logging instruction traces in a ring buffer.

### DIFF
--- a/accel/tcg/tcg-runtime.h
+++ b/accel/tcg/tcg-runtime.h
@@ -333,6 +333,8 @@ DEF_HELPER_FLAGS_4(gvec_leu64, TCG_CALL_NO_RWG, void, ptr, ptr, ptr, i32)
 DEF_HELPER_FLAGS_5(gvec_bitsel, TCG_CALL_NO_RWG, void, ptr, ptr, ptr, ptr, i32)
 
 #ifdef CONFIG_TCG_LOG_INSTR
+DEF_HELPER_FLAGS_2(qemu_log_instr_buffered_mode, TCG_CALL_NO_RWG, void, env, i32)
+DEF_HELPER_FLAGS_1(qemu_log_instr_buffer_flush, TCG_CALL_NO_RWG, void, env)
 DEF_HELPER_FLAGS_2(qemu_log_instr_start, TCG_CALL_NO_WG, void, env, tl)
 DEF_HELPER_FLAGS_2(qemu_log_instr_user_start, TCG_CALL_NO_WG, void, env, tl)
 DEF_HELPER_FLAGS_2(qemu_log_instr_stop, TCG_CALL_NO_WG, void, env, tl)

--- a/include/exec/log_instr.h
+++ b/include/exec/log_instr.h
@@ -176,6 +176,12 @@ void qemu_log_instr_set_level(CPUArchState *env, qemu_log_instr_loglevel_t lvl);
 void qemu_log_instr_allcpu_set_level(qemu_log_instr_loglevel_t lvl);
 
 /*
+ * Emit all buffered instruction logs.
+ * This is only relevant when tracing in buffered mode.
+ */
+void qemu_log_instr_flush(CPUArchState *env);
+
+/*
  * Drop the current buffered entry and ignore logging until next commit.
  */
 void qemu_log_instr_drop(CPUArchState *env);
@@ -273,6 +279,7 @@ void qemu_log_instr_extra(CPUArchState *env, const char *msg, ...);
 #define	qemu_log_instr_start(env, mode, pc)
 #define	qemu_log_instr_stop(env, mode, pc)
 #define	qemu_log_instr_mode_switch(...)
+#define qemu_log_instr_flush(env)
 #define	qemu_log_instr_reg(...)
 #define	qemu_log_instr_cap(...)
 #define	qemu_log_instr_mem(...)

--- a/include/qemu/log_instr.h
+++ b/include/qemu/log_instr.h
@@ -110,8 +110,10 @@ typedef struct {
 
     /* Ring buffer of log_instr_info */
     GArray *instr_info;
-    /* Ring buffer head index */
+    /* Ring buffer index of the next entry to write */
     size_t ring_head;
+    /* Ring buffer index of the first entry to dump */
+    size_t ring_tail;
 } cpu_log_instr_state_t;
 
 /*

--- a/include/qemu/log_instr.h
+++ b/include/qemu/log_instr.h
@@ -104,13 +104,14 @@ typedef struct {
     bool force_drop;
     /* We are starting to log at the next commit */
     bool starting;
-    /*
-     * Opaque handle to the current instruction info
-     * TODO(am2419): It would be interesting to have a ring buffer
-     * of log_instr_info here, so that we can avoid dumping to file
-     * all the time.
-     */
-    struct cpu_log_instr_info *instr_info;
+    /* Per-CPU flags */
+    int flags;
+#define QEMU_LOG_INSTR_FLAG_BUFFERED 1
+
+    /* Ring buffer of log_instr_info */
+    GArray *instr_info;
+    /* Ring buffer head index */
+    size_t ring_head;
 } cpu_log_instr_state_t;
 
 /*

--- a/target/mips/translate.c
+++ b/target/mips/translate.c
@@ -4390,6 +4390,15 @@ static void gen_logic_imm(DisasContext *ctx, uint32_t opc,
                 gen_helper_smp_yield(cpu_env);
             }
 
+            /* Buffered tracing switches, same as RISC-V */
+            if ((uint16_t)imm == 0x01 || (uint16_t)imm == 0x02) {
+                TCGv_i32 ttmp = tcg_const_i32(((uint16_t)imm == 0x01));
+                gen_helper_qemu_log_instr_buffered_mode(cpu_env, ttmp);
+                tcg_temp_free_i32(ttmp);
+            }
+            if ((uint16_t)imm == 0x03)
+                gen_helper_qemu_log_instr_buffer_flush(cpu_env);
+
         }
 #endif /* CONFIG_TCG_LOG_INSTR */
         return;

--- a/target/riscv/insn_trans/trans_rvi.inc.c
+++ b/target/riscv/insn_trans/trans_rvi.inc.c
@@ -287,8 +287,22 @@ static bool trans_slti(DisasContext *ctx, arg_slti *a)
      */
     if (unlikely(a->rd == 0)) {
         TCGv tpc = tcg_const_tl(ctx->base.pc_next);
-        /* gen_update_cpu_pc(ctx->base.pc_next); */
+        TCGv_i32 ttmp;
+
         switch (a->imm) {
+        case 0x01:
+            ttmp = tcg_const_i32(true);
+            gen_helper_qemu_log_instr_buffered_mode(cpu_env, ttmp);
+            tcg_temp_free_i32(ttmp);
+            break;
+        case 0x02:
+            ttmp = tcg_const_i32(false);
+            gen_helper_qemu_log_instr_buffered_mode(cpu_env, ttmp);
+            tcg_temp_free_i32(ttmp);
+            break;
+        case 0x03:
+            gen_helper_qemu_log_instr_buffer_flush(cpu_env);
+            break;
         case 0x1b:
             gen_helper_qemu_log_instr_start(cpu_env, tpc);
             ctx->base.is_jmp = DISAS_NORETURN;

--- a/target/riscv/insn_trans/trans_rvi.inc.c
+++ b/target/riscv/insn_trans/trans_rvi.inc.c
@@ -290,13 +290,8 @@ static bool trans_slti(DisasContext *ctx, arg_slti *a)
         TCGv_i32 ttmp;
 
         switch (a->imm) {
-        case 0x01:
-            ttmp = tcg_const_i32(true);
-            gen_helper_qemu_log_instr_buffered_mode(cpu_env, ttmp);
-            tcg_temp_free_i32(ttmp);
-            break;
-        case 0x02:
-            ttmp = tcg_const_i32(false);
+        case 0x01: case 0x02:
+            ttmp = tcg_const_i32(a->imm == 0x01);
             gen_helper_qemu_log_instr_buffered_mode(cpu_env, ttmp);
             tcg_temp_free_i32(ttmp);
             break;


### PR DESCRIPTION
A ring buffer is allocated for each CPU. Instructions traced are kept in memory until
the user triggers a buffer flush. This allows to selectively dump instructions upon
any software-defined event (e.g. exception handling, kernel panic).
Three magic nop constant are allocated for this:
- 0x01: enable tracing to the ring buffer
- 0x02: disable tracing to the ring buffer
- 0x03: dump valid entries in the ring buffer to the trace file
These are available for both MIPS and RISC-V.