### PR TITLE
Update cpu_cheri.h

### DIFF
--- a/target/cheri-common/cpu_cheri.h
+++ b/target/cheri-common/cpu_cheri.h
@@ -138,7 +138,7 @@ static inline void cheri_cpu_get_tb_cpu_state(const cap_register_t *pcc,
     *cs_top = cap_get_top(pcc);
     *cheri_flags |=
         cheri_cap_perms_valid_for_exec(pcc) ? TB_FLAG_CHERI_PCC_VALID : 0;
-    if (cs_base == 0 && cap_get_top65(pcc) == CAP_MAX_TOP) {
+    if (*cs_base == 0 && cap_get_top65(pcc) == CAP_MAX_TOP) {
         *cheri_flags |= TB_FLAG_PCC_FULL_AS;
     }
     if (ddc->cr_tag && cap_is_unsealed(ddc)) {


### PR DESCRIPTION
TB_FLAG_PCC_FULL_AS is never getting set because of a missing *. At the very least this should get rid of a tcg branch before tcg optimisation takes place.