### PR TITLE
Memory versioning implementation (do not merge)

### DIFF
--- a/accel/tcg/cputlb.c
+++ b/accel/tcg/cputlb.c
@@ -2,6 +2,7 @@
  *  Common CPU TLB handling
  *
  *  Copyright (c) 2003 Fabrice Bellard
+ *  Copyright (c) 2021 Microsoft
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -1123,9 +1124,11 @@ void tlb_set_page_with_attrs(CPUState *cpu, target_ulong vaddr,
      * Getting tagmem can cause an invalidation, so best to do this before
      * any other entries are modified.
      */
+    uintptr_t vermem;
     uintptr_t tagmem = (uintptr_t)cheri_tagmem_for_addr(
-        env, vaddr, section->mr->ram_block, xlat, size, &prot, tag_setting);
+        env, vaddr, section->mr->ram_block, xlat, size, &prot, tag_setting, (void **) &vermem);
     assert((tagmem & TLBENTRYCAP_MASK) == 0);
+    assert((vermem & TLBENTRYVER_MASK) == 0);
 #endif
 
     address = vaddr_page;
@@ -1247,6 +1250,11 @@ void tlb_set_page_with_attrs(CPUState *cpu, target_ulong vaddr,
     }
     if (prot & PAGE_SC_TRAP) {
         desc->iotlb[index].tagmem_write |= TLBENTRYCAP_FLAG_TRAP;
+    }
+
+    desc->iotlb[index].vermem = vermem;
+    if (prot & PAGE_SV_TRAP) {
+        desc->iotlb[index].vermem |= TLBENTRYVER_TRAP;
     }
 
 #endif
@@ -1459,7 +1467,9 @@ static bool victim_tlb_hit(CPUArchState *env, size_t mmu_idx, size_t index,
 #ifdef TARGET_CHERI
         if (cap_write && ((env_tlb(env)->d[mmu_idx].viotlb[vidx].tagmem_write &
                            TLBENTRYCAP_INVALID_WRITE_MASK) ==
-                          TLBENTRYCAP_INVALID_WRITE_VALUE)) {
+                           TLBENTRYCAP_INVALID_WRITE_VALUE || 
+                           env_tlb(env)->d[mmu_idx].viotlb[vidx].vermem ==
+                           TLBENTRYVER_INVALID)) {
             continue;
         }
 #endif
@@ -1591,6 +1601,7 @@ probe_access_internal(CPUArchState *env, target_ulong addr, int fault_size,
          * done with a single probe.
          */
     case MMU_DATA_CAP_STORE:
+    case MMU_VERSION_STORE: // we don't currently need the address but treat the same wrt TLB_NOTDIRTY etc.
         elt_ofs = offsetof(CPUTLBEntry, addr_write);
         break;
     case MMU_INST_FETCH:
@@ -1613,11 +1624,18 @@ probe_access_internal(CPUArchState *env, target_ulong addr, int fault_size,
               .tagmem_write &
           TLBENTRYCAP_INVALID_WRITE_MASK) == TLBENTRYCAP_INVALID_WRITE_VALUE))
         tag_write_invalid = true;
+    if (access_type == MMU_VERSION_STORE &&
+        (env_tlb(env)
+             ->d[mmu_idx]
+             .iotlb[tlb_index(env, mmu_idx, addr)]
+             .vermem == TLBENTRYVER_INVALID))
+        tag_write_invalid = true;
 #endif
 
     if (!tlb_hit_page(tlb_addr, page_addr) || tag_write_invalid) {
         if (!victim_tlb_hit(env, mmu_idx, index, elt_ofs, page_addr,
-                            access_type == MMU_DATA_CAP_STORE)) {
+                            access_type == MMU_DATA_CAP_STORE ||
+                            access_type == MMU_VERSION_STORE)) {
             CPUState *cs = env_cpu(env);
             CPUClass *cc = CPU_GET_CLASS(cs);
 
@@ -1693,6 +1711,7 @@ probe_access_inlined(CPUArchState *env, target_ulong addr, int size,
             bool is_write =
 #ifdef TARGET_CHERI
                 access_type == MMU_DATA_CAP_STORE ||
+                access_type == MMU_VERSION_STORE ||
 #endif
                 access_type == MMU_DATA_STORE;
             int wp_access = is_write ? BP_MEM_WRITE : BP_MEM_READ;

--- a/accel/tcg/probe-access.inc.c
+++ b/accel/tcg/probe-access.inc.c
@@ -32,4 +32,11 @@ void *probe_cap_write(CPUArchState *env, target_ulong addr, int size,
     return probe_access_inlined(env, addr, size, MMU_DATA_CAP_STORE, mmu_idx,
                                 retaddr);
 }
+
+void *probe_ver_write(CPUArchState *env, target_ulong addr, int size,
+                      int mmu_idx, uintptr_t retaddr)
+{
+    return probe_access_inlined(env, addr, size, MMU_VERSION_STORE, mmu_idx,
+                                retaddr);
+}
 #endif

--- a/include/exec/cpu-all.h
+++ b/include/exec/cpu-all.h
@@ -286,6 +286,8 @@ extern intptr_t qemu_host_page_mask;
 #define PAGE_C_BITS                                                            \
     (PAGE_LC_CLEAR | PAGE_LC_TRAP | PAGE_SC_TRAP | PAGE_SC_CLEAR |             \
      PAGE_LC_TRAP_ANY)
+/* Trap on store version */
+#define PAGE_SV_TRAP  0x80000
 #else
 #define PAGE_C_BITS 0
 #endif

--- a/include/exec/cpu-defs.h
+++ b/include/exec/cpu-defs.h
@@ -2,6 +2,7 @@
  * common defines for all CPUs
  *
  * Copyright (c) 2003 Fabrice Bellard
+ * Copyright (c) 2021 Microsoft
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -178,6 +179,17 @@ typedef struct CPUIOTLBEntry {
     (TLBENTRYCAP_FLAG_TRAP | TLBENTRYCAP_FLAG_CLEAR)
 #define TLBENTRYCAP_INVALID_WRITE_VALUE (TLBENTRYCAP_FLAG_TRAP)
     uintptr_t tagmem_write;
+
+/* Similar to tagmem above but there is no clearing access */
+#define TLBENTRYVER_MASK    ((uintptr_t) 1)
+/* Trap if attempting to write version */
+#define TLBENTRYVER_TRAP    ((uintptr_t) 1)
+#define TLBENTRYVER_INVALID ((uintptr_t) (~0 & ~TLBENTRYVER_MASK))
+/* Entry that reads as all zeros, attempts allocation on write */
+#define ALL_ZERO_VERMEM     ((void *) TLBENTRYVER_INVALID)
+    /* Pointer to version memory for page. Will hopefully get away with single pointer
+       for both reads and writes. */
+    uintptr_t vermem;
 #endif
     MemTxAttrs attrs;
 } CPUIOTLBEntry;
@@ -189,6 +201,16 @@ typedef struct CPUIOTLBEntry {
     })
 #define IOTLB_GET_TAGMEM_FLAGS(iotlbentry, rw)                                 \
     ((uintptr_t)iotlbentry->tagmem_##rw & TLBENTRYCAP_MASK);
+
+#define IOTLB_GET_VERMEM(iotlbentry)                                       \
+    ({                                                                         \
+        cheri_debug_assert(iotlbentry->vermem != (uintptr_t)0);           \
+        (void *)((uintptr_t)iotlbentry->vermem & ~TLBENTRYVER_MASK);      \
+    })
+
+#define IOTLB_GET_VERMEM_FLAGS(iotlbentry)                                \
+    (iotlbentry->vermem & TLBENTRYVER_MASK)
+
 /*
  * Data elements that are per MMU mode, minus the bits accessed by
  * the TCG fast path.

--- a/include/exec/exec-all.h
+++ b/include/exec/exec-all.h
@@ -402,6 +402,9 @@ void *probe_read(CPUArchState *env, target_ulong addr, int size, int mmu_idx,
 #ifdef TARGET_CHERI
 void *probe_cap_write(CPUArchState *env, target_ulong addr, int size,
                       int mmu_idx, uintptr_t retaddr);
+
+void *probe_ver_write(CPUArchState *env, target_ulong addr, int size,
+                      int mmu_idx, uintptr_t retaddr);
 #endif
 
 /**

--- a/include/hw/core/cpu.h
+++ b/include/hw/core/cpu.h
@@ -73,6 +73,8 @@ typedef enum MMUAccessType {
     MMU_INST_FETCH = 2,
     MMU_DATA_CAP_LOAD = 3,
     MMU_DATA_CAP_STORE = 4,
+    MMU_VERSION_LOAD = 5, /* XXX not currently used because version loads use same perms as data (apparently MMU_DATA_CAP_LOAD is the same) */
+    MMU_VERSION_STORE = 6,
 } MMUAccessType;
 
 typedef struct CPUWatchpoint CPUWatchpoint;

--- a/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap_128.h
+++ b/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap_128.h
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2018-2020 Alex Richardson
+ * Copyright (c) 2021 Microsoft <robert.norton@microsoft.com>
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -55,6 +56,8 @@
  *
  * Morello embeds the user permissions in the middle of the hardware permissions.
  */
+
+#define CC_HAVE_VERSION 1
 
 // The following macros are expected to be defined
 #undef CC_BITS
@@ -125,7 +128,12 @@ enum {
     _CC_FIELD(HWPERMS, 123, 112),
     _CC_FIELD(RESERVED, 111, 110),
     _CC_FIELD(FLAGS, 109, 109),
+#ifdef CC_HAVE_VERSION
+    _CC_FIELD(VERSION, 108, 105),
+    _CC_FIELD(OTYPE, 104, 91),
+#else
     _CC_FIELD(OTYPE, 108, 91),
+#endif
     _CC_FIELD(EBT, 90, 64),
 
     _CC_FIELD(INTERNAL_EXPONENT, 90, 90),
@@ -149,6 +157,7 @@ enum {
 #define CC128_BOT_WIDTH CC128_FIELD_EXP_ZERO_BOTTOM_SIZE
 #define CC128_BOT_INTERNAL_EXP_WIDTH CC128_FIELD_EXP_NONZERO_BOTTOM_SIZE
 #define CC128_EXP_LOW_WIDTH CC128_FIELD_EXPONENT_LOW_PART_SIZE
+#define CC128_VERSION_BITS CC128_FIELD_VERSION_SIZE
 
 #ifdef CC_IS_MORELLO
 
@@ -244,13 +253,24 @@ enum _CC_N(OTypes) {
 
 _CC_STATIC_ASSERT_SAME(CC128_MANTISSA_WIDTH, CC128_FIELD_EXP_ZERO_BOTTOM_SIZE);
 
+#ifdef CC_HAVE_VERSION
+enum _CC_N(Versions) {
+    CC128_VERSION_UNVERSIONED = 0,
+    CC128_MAX_VERSION = ((1u << CC128_VERSION_BITS) - 1u),
+};
+#endif
+
 #include "cheri_compressed_cap_common.h"
 
 // Sanity-check mask is the expected NULL encoding
 #ifdef CC_IS_MORELLO
 _CC_STATIC_ASSERT_SAME(CC128_NULL_XOR_MASK, UINT64_C(0x0000000040070007));
 #else
+#ifdef CC_HAVE_VERSION
+_CC_STATIC_ASSERT_SAME(CC128_NULL_XOR_MASK, UINT64_C(0x000001fffc018004));
+#else
 _CC_STATIC_ASSERT_SAME(CC128_NULL_XOR_MASK, UINT64_C(0x00001ffffc018004));
+#endif
 #endif
 
 __attribute__((deprecated("Use cc128_compress_raw"))) static inline uint64_t

--- a/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap_64.h
+++ b/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap_64.h
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2018-2020 Alex Richardson
+ * Copyright (c) 2021 Microsoft <robert.norton@microsoft.com>
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -84,6 +85,7 @@ enum {
     _CC_FIELD(EXPONENT_LOW_PART, 34, 32),
     _CC_FIELD(RESERVED, 31, 32), /* No reserved bits */
     _CC_FIELD(UPERMS, 31, 32), /* No uperms */
+    _CC_FIELD(VERSION, 31, 32), /* No version */
 };
 #pragma GCC diagnostic pop
 _CC_STATIC_ASSERT_SAME(CC64_FIELD_UPERMS_SIZE, 0);

--- a/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap_common.h
+++ b/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap_common.h
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2018 Lawrence Esswood
  * Copyright (c) 2018-2020 Alex Richardson
+ * Copyright (c) 2021 Microsoft <robert.norton@microsoft.com>
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -64,6 +65,9 @@ enum {
     _CC_N(NULL_PESBT) = _CC_ENCODE_FIELD(0, UPERMS) | _CC_ENCODE_FIELD(0, HWPERMS) | _CC_ENCODE_FIELD(0, RESERVED) |
                         _CC_ENCODE_FIELD(0, FLAGS) | _CC_ENCODE_FIELD(1, INTERNAL_EXPONENT) |
                         _CC_ENCODE_FIELD(_CC_N(OTYPE_UNSEALED), OTYPE) |
+#ifdef CC_HAVE_VERSION
+                        _CC_ENCODE_FIELD(_CC_N(VERSION_UNVERSIONED), VERSION) |
+#endif
                         _CC_ENCODE_FIELD(_CC_N(NULL_T), EXP_NONZERO_TOP) | _CC_ENCODE_FIELD(0, EXP_NONZERO_BOTTOM) |
                         _CC_ENCODE_FIELD(_CC_N(NULL_EXP) >> _CC_N(FIELD_EXPONENT_LOW_PART_SIZE), EXPONENT_HIGH_PART) |
                         _CC_ENCODE_FIELD(_CC_N(NULL_EXP) & _CC_N(FIELD_EXPONENT_LOW_PART_MAX_VALUE), EXPONENT_LOW_PART),
@@ -88,7 +92,7 @@ enum {
 #define _CC_MAX_TOP _CC_N(MAX_TOP)
 #define _CC_CURSOR_MASK _CC_N(CURSOR_MASK)
 // Check that the sizes of the individual fields match up
-_CC_STATIC_ASSERT_SAME(_CC_N(FIELD_EBT_SIZE) + _CC_N(FIELD_OTYPE_SIZE) + _CC_N(FIELD_FLAGS_SIZE) +
+_CC_STATIC_ASSERT_SAME(_CC_N(FIELD_EBT_SIZE) + _CC_N(FIELD_VERSION_SIZE) + _CC_N(FIELD_OTYPE_SIZE) + _CC_N(FIELD_FLAGS_SIZE) +
                            _CC_N(FIELD_RESERVED_SIZE) + _CC_N(FIELD_HWPERMS_SIZE) + _CC_N(FIELD_UPERMS_SIZE),
                        _CC_ADDR_WIDTH);
 _CC_STATIC_ASSERT_SAME(_CC_N(FIELD_INTERNAL_EXPONENT_SIZE) + _CC_N(FIELD_EXP_ZERO_TOP_SIZE) +
@@ -113,6 +117,9 @@ _CC_STATIC_ASSERT(_CC_N(MAX_RESERVED_OTYPE) <= _CC_N(MAX_REPRESENTABLE_OTYPE), "
 struct _cc_N(cap);
 static inline uint8_t _cc_N(get_flags)(const struct _cc_N(cap)* cap);
 static inline uint32_t _cc_N(get_otype)(const struct _cc_N(cap)* cap);
+#ifdef CC_HAVE_VERSION
+static inline uint8_t _cc_N(get_version)(const struct _cc_N(cap)* cap);
+#endif
 static inline uint32_t _cc_N(get_perms)(const struct _cc_N(cap)* cap);
 static inline uint8_t _cc_N(get_reserved)(const struct _cc_N(cap)* cap);
 static inline uint32_t _cc_N(get_uperms)(const struct _cc_N(cap)* cap);
@@ -254,6 +261,9 @@ ALL_WRAPPERS(UPERMS, uperms, uint32_t)
 ALL_WRAPPERS(OTYPE, otype, uint32_t)
 ALL_WRAPPERS(FLAGS, flags, uint8_t)
 ALL_WRAPPERS(RESERVED, reserved, uint8_t)
+#ifdef CC_HAVE_VERSION
+ALL_WRAPPERS(VERSION, version, uint8_t)
+#endif
 #undef ALL_WRAPPERS
 
 /// Extract the bits used for bounds and infer the top two bits of T
@@ -696,7 +706,7 @@ static inline bool _cc_N(is_representable_new_addr)(bool sealed, _cc_addr_t base
         c._cr_cursor = cursor;
         // important to set as compress assumes this is in bounds
         c.cr_pesbt = _CC_ENCODE_FIELD(_CC_N(UPERMS_ALL), UPERMS) | _CC_ENCODE_FIELD(_CC_N(PERMS_ALL), HWPERMS) |
-                     _CC_ENCODE_FIELD(sealed ? 42 : _CC_N(OTYPE_UNSEALED), OTYPE);
+                     _CC_ENCODE_FIELD(sealed ? 42 : _CC_N(OTYPE_UNSEALED), OTYPE); /* XXX should set version too? seems redundant */
         /* Get an EBT */
         bool exact_input = false;
         _cc_N(update_ebt)(&c, _cc_N(compute_ebt)(base, top, NULL, &exact_input));
@@ -844,6 +854,9 @@ static inline bool _cc_N(setbounds_impl)(_cc_cap_t* cap, _cc_addr_t req_base, _c
 
     // TODO: find a faster way to compute top and bot:
     const _cc_addr_t pesbt = _CC_ENCODE_FIELD(0, UPERMS) | _CC_ENCODE_FIELD(0, HWPERMS) |
+#ifdef CC_HAVE_VERSION
+                             _CC_ENCODE_FIELD(_CC_N(VERSION_UNVERSIONED), VERSION) | /* I think setting this here is redundant but zero anyway... */
+#endif
                              _CC_ENCODE_FIELD(_CC_N(OTYPE_UNSEALED), OTYPE) | _CC_ENCODE_FIELD(new_ebt, EBT);
     _cc_cap_t new_cap;
     _cc_N(decompress_raw)(pesbt, cursor, cap->cr_tag, &new_cap);
@@ -918,8 +931,12 @@ static inline _cc_cap_t _cc_N(make_max_perms_cap)(_cc_addr_t base, _cc_addr_t cu
     creg._cr_cursor = cursor;
     creg.cr_bounds_valid = true;
     creg._cr_top = top;
-    creg.cr_pesbt = _CC_ENCODE_FIELD(_CC_N(UPERMS_ALL), UPERMS) | _CC_ENCODE_FIELD(_CC_N(PERMS_ALL), HWPERMS) |
-                    _CC_ENCODE_FIELD(_CC_N(OTYPE_UNSEALED), OTYPE);
+    creg.cr_pesbt = _CC_ENCODE_FIELD(_CC_N(UPERMS_ALL), UPERMS)
+                     | _CC_ENCODE_FIELD(_CC_N(PERMS_ALL), HWPERMS)
+#ifdef CC_HAVE_VERSION
+                     | _CC_ENCODE_FIELD(_CC_N(VERSION_UNVERSIONED), VERSION)
+#endif
+                     | _CC_ENCODE_FIELD(_CC_N(OTYPE_UNSEALED), OTYPE);
     creg.cr_tag = true;
     creg.cr_exp = _CC_N(NULL_EXP);
     bool exact_input = false;

--- a/target/cheri-common/cheri-helper-common.h
+++ b/target/cheri-common/cheri-helper-common.h
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2020 Alex Richardson
+ * Copyright (c) 2021 Microsoft <robert.norton@microsoft.com>
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -66,6 +67,8 @@ DEF_HELPER_FLAGS_2(cgetoffset, 0, tl, env, i32)
 DEF_HELPER_FLAGS_2(cgetsealed, 0, tl, env, i32)
 DEF_HELPER_FLAGS_2(cgettag, 0, tl, env, i32)
 DEF_HELPER_FLAGS_2(cgettype, 0, tl, env, i32)
+DEF_HELPER_FLAGS_2(cgetversion, 0, tl, env, i32)
+DEF_HELPER_2(cloadversion, tl, env, i32)
 
 // Two operands (cap cap)
 DEF_HELPER_3(ccleartag, void, env, i32, i32)
@@ -79,6 +82,7 @@ DEF_HELPER_3(ccheckperm, void, env, i32, tl)
 DEF_HELPER_3(cgetpccsetoffset, void, env, i32, tl)
 DEF_HELPER_3(cgetpccincoffset, void, env, i32, tl)
 DEF_HELPER_3(cgetpccsetaddr, void, env, i32, tl)
+DEF_HELPER_3(cstoreversion, void, env, i32, tl)
 
 // Two operands (int int)
 DEF_HELPER_FLAGS_2(crap, TCG_CALL_NO_RWG_SE, tl, env, tl)
@@ -118,12 +122,14 @@ DEF_HELPER_4(csetboundsexact, void, env, i32, i32, tl)
 DEF_HELPER_4(csetflags, void, env, i32, i32, tl)
 #endif
 DEF_HELPER_4(csetoffset, void, env, i32, i32, tl)
+DEF_HELPER_4(csetversion, void, env, i32, i32, tl)
 
 // Three operands (int cap cap)
 DEF_HELPER_FLAGS_3(csub, 0, tl, env, i32, i32)
 DEF_HELPER_FLAGS_3(ctestsubset, 0, tl, env, i32, i32)
 DEF_HELPER_FLAGS_3(cseqx, 0, tl, env, i32, i32)
 DEF_HELPER_FLAGS_3(ctoptr, 0, tl, env, i32, i32)
+DEF_HELPER_3(camocdecversion, tl, env, i32, i32)
 
 // Loads+Stores
 DEF_HELPER_4(cap_load_check, cap_checked_ptr, env, i32, tl, i32)

--- a/target/cheri-common/cheri-translate-utils.h
+++ b/target/cheri-common/cheri-translate-utils.h
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2020 Alex Richardson
+ * Copyright (c) 2021 Microsoft <robert.norton@microsoft.com>
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -207,7 +208,7 @@ static inline void _generate_special_checked_ptr(
         tcg_gen_mov_tl((TCGv)checked_addr, integer_addr);
     }
 
-    if (unlikely(!have_cheri_tb_flags(ctx, tb_perm_flags))) {
+    if (unlikely(!have_cheri_tb_flags(ctx, tb_perm_flags | (use_ddc ? TB_FLAG_CHERI_DDC_UNVERSIONED : 0)))) {
         // PCC/DDC is untagged, sealed, or missing permissions
         TCGv_i32 tperms = tcg_const_i32(req_perms);
         cheri_tcg_prepare_for_unconditional_exception(&ctx->base);

--- a/target/cheri-common/cheri_defs.h
+++ b/target/cheri-common/cheri_defs.h
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2020 Alex Richardson
+ * Copyright (c) 2021 Microsoft <robert.norton@microsoft.com>
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -108,6 +109,15 @@
 #define CAP_NULL_PESBT CAP_CC(NULL_PESBT)
 #define CAP_NULL_XOR_MASK CAP_CC(NULL_XOR_MASK)
 
+#define CAP_VERSION_UNVERSIONED CAP_CC(VERSION_UNVERSIONED)
+#define CAP_MAX_VERSION CAP_CC(MAX_VERSION)
+/* size of memory version granule. In principle this is independent of CAP_SIZE
+    but in practice it will probably be the same. */
+#  define CHERI_VERSION_GRANULE_SIZE (CHERI_CAP_SIZE)
+/* Integer type big enough to hold a memory granule version. The actually 
+   supported number of versions might be smaller e.g. 4-bits */
+typedef uint8_t cap_version_t;
+
 typedef CAP_cc(cap_t) cap_register_t;
 typedef CAP_cc(offset_t) cap_offset_t;
 typedef CAP_cc(length_t) cap_length_t;
@@ -170,6 +180,8 @@ typedef enum CheriTbFlags {
     TB_FLAG_CHERI_PCC_FULL_AS =
         TB_FLAG_CHERI_PCC_BASE_ZERO | TB_FLAG_CHERI_PCC_TOP_MAX,
     TB_FLAG_CHERI_PCC_READABLE = (1 << 9),
+    /* DDC is tagged, unsealed and unversioned */
+    TB_FLAG_CHERI_DDC_UNVERSIONED = (1 << 10),
 
     /* Useful for CHERI-specific flags on various platforms if the normal flags
        overflowed */

--- a/target/cheri-common/cheri_tagmem.h
+++ b/target/cheri-common/cheri_tagmem.h
@@ -4,6 +4,7 @@
  * Copyright (c) 2015-2016 Stacey Son <sson@FreeBSD.org>
  * Copyright (c) 2016-2018 Alfredo Mazzinghi <am2419@cl.cam.ac.uk>
  * Copyright (c) 2016-2018 Alex Richardson <Alexander.Richardson@cl.cam.ac.uk>
+ * Copyright (c) 2021 Microsoft <robert.norton@microsoft.com>
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -82,5 +83,29 @@ void *cheri_tag_set(CPUArchState *env, target_ulong vaddr, int reg,
 
 void *cheri_tagmem_for_addr(CPUArchState *env, target_ulong vaddr,
                             RAMBlock *ram, ram_addr_t ram_offset, size_t size,
-                            int *prot, bool tag_write);
+                            int *prot, bool tag_write, void **vermem_out);
+
+/**
+ * Returns the version of the granule-aligned @vaddr
+ * @reg XXX is redundant on RISC-V
+ * @ret_paddr is used to return the physical address if non-NULL 
+ * @prot returns protection attributes form translation. Must not be NULL.
+ * May cause translation faults as for data loads.
+ */
+cap_version_t cheri_version_get_aligned(CPUArchState *env, target_ulong vaddr, int reg,
+                  hwaddr *ret_paddr, int *prot, uintptr_t pc);
+/**
+ * Sets the version of the granule-aligned @vaddr to @val.
+ * @reg XXX is redundant on RISC-V
+ * @ret_paddr is used to return the physical address fr
+ * May cause translation faults as for data stores.
+ */
+void cheri_version_set_aligned(CPUArchState *env, target_ulong vaddr, int reg, hwaddr* ret_paddr, uintptr_t pc, cap_version_t val);
+/**
+ * Returns true if the memory version matches the give @expected version for all
+ * granules in [vaddr, vaddr+size). May cause translation faults as per the 
+ * access type rw.
+ */
+bool cheri_version_check(CPUArchState *env, target_ulong vaddr, int32_t size,
+                         MMUAccessType rw, uintptr_t pc, cap_version_t expected);
 #endif /* TARGET_CHERI */

--- a/target/cheri-common/cheri_utils.h
+++ b/target/cheri-common/cheri_utils.h
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2019 Alex Richardson
+ * Copyright (c) 2021 Microsoft <robert.norton@microsoft.com>
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -95,6 +96,11 @@ static inline uint32_t cap_get_perms(const cap_register_t *c)
 static inline uint8_t cap_get_flags(const cap_register_t *c)
 {
     return CAP_cc(get_flags)(c);
+}
+
+static inline cap_version_t cap_get_version(const cap_register_t *c)
+{
+    return CAP_cc(get_version)(c);
 }
 
 static inline bool cap_has_reserved_bits_set(const cap_register_t *c)

--- a/target/cheri-common/cpu_cheri.h
+++ b/target/cheri-common/cpu_cheri.h
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2018-2020 Alex Richardson
+ * Copyright (c) 2021 Microsoft <robert.norton@microsoft.com>
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -163,6 +164,8 @@ static inline void cheri_cpu_get_tb_cpu_state(const cap_register_t *pcc,
             *cheri_flags |= TB_FLAG_CHERI_DDC_CURSOR_ZERO;
         if (cap_get_top_full(ddc) == CAP_MAX_TOP)
             *cheri_flags |= TB_FLAG_CHERI_DDC_TOP_MAX;
+        if (cap_get_version(ddc) == CAP_VERSION_UNVERSIONED)
+            *cheri_flags |= TB_FLAG_CHERI_DDC_UNVERSIONED;
     }
 }
 

--- a/target/mips/cheri-archspecific-early.h
+++ b/target/mips/cheri-archspecific-early.h
@@ -92,6 +92,7 @@ typedef enum CheriCapExc {
     CapEx_AccessCCallIDCViolation       = 0x1A,  /* Access IDC in a CCall delay slot */
     CapEx_PermitUnsealViolation         = 0x1B,  /* Permit_Unseal violation */
     CapEx_PermitSetCIDViolation         = 0x1C,  /* Permit_SetCID violation */
+    CapEx_VersionViolation              = 0x1D,  /* Version violation */
     // 0x1d-0x1f Reserved
 } CheriCapExcCause;
 

--- a/target/mips/cheri-archspecific.h
+++ b/target/mips/cheri-archspecific.h
@@ -118,6 +118,15 @@ static inline void QEMU_NORETURN raise_store_tag_exception(CPUArchState *env,
     do_raise_c2_exception_impl(env, CapEx_TLBNoStoreCap, cb, retpc);
 }
 
+static inline void QEMU_NORETURN raise_store_ver_exception(CPUArchState *env,
+                                                           target_ulong va,
+                                                           int cb,
+                                                           uintptr_t retpc)
+{
+    env->CP0_BadVAddr = va;
+    do_raise_c2_exception_impl(env, CapEx_TLBNoStoreCap, cb, retpc);
+}
+
 static inline void QEMU_NORETURN raise_unaligned_load_exception(
     CPUArchState *env, target_ulong addr, uintptr_t retpc)
 {

--- a/target/riscv/cheri-archspecific-early.h
+++ b/target/riscv/cheri-archspecific-early.h
@@ -73,6 +73,7 @@ typedef enum CheriCapExc {
     CapEx_AccessCCallIDCViolation       = 0x1A,
     CapEx_PermitUnsealViolation         = 0x1B,
     CapEx_PermitSetCIDViolation         = 0x1C,
+    CapEx_VersionViolation              = 0x1D,
     // 0x1d - 0x1f reserved
 } CheriCapExcCause;
 

--- a/target/riscv/cheri-archspecific.h
+++ b/target/riscv/cheri-archspecific.h
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2020 Alex Richardson <Alexander.Richardson@cl.cam.ac.uk>
+ * Copyright (c) 2021 Microsoft <robert.norton@microsoft.com>
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -75,6 +76,19 @@ static inline void QEMU_NORETURN raise_store_tag_exception(CPUArchState *env,
 #endif
 }
 
+static inline void QEMU_NORETURN raise_store_ver_exception(CPUArchState *env,
+                                                           target_ulong va,
+                                                           int reg,
+                                                           uintptr_t retpc)
+{
+#ifdef TARGET_RISCV32
+    g_assert_not_reached();
+#else
+    env->badaddr = va;
+    riscv_raise_exception(env, RISCV_EXCP_STORE_AMO_VER_PAGE_FAULT, retpc);
+#endif
+}
+
 static inline void QEMU_NORETURN raise_unaligned_load_exception(
     CPUArchState *env, target_ulong addr, uintptr_t retpc)
 {
@@ -89,6 +103,13 @@ static inline void QEMU_NORETURN raise_unaligned_store_exception(
     // Note: RISCV_EXCP_STORE_AMO_ADDR_MIS means "Store/AMO address misaligned"
     riscv_raise_exception(env, RISCV_EXCP_STORE_AMO_ADDR_MIS, retpc);
 
+}
+
+static inline void QEMU_NORETURN raise_version_exception (
+    CPUArchState *env, target_ulong addr, uintptr_t retpc)
+{
+    env->badaddr = addr;
+    riscv_raise_exception(env, RISCV_EXCP_VERSION, retpc);
 }
 
 static inline bool validate_jump_target(CPUArchState *env,

--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -106,7 +106,8 @@ const char * const riscv_excp_names[] = {
     [RISCV_EXCP_LOAD_CAP_PAGE_FAULT] = "load_cap_page_fault",
     [RISCV_EXCP_STORE_AMO_CAP_PAGE_FAULT] = "store_cap_page_fault",
 #endif
-    [RISCV_EXCP_CHERI] = "cheri_fault"
+    [RISCV_EXCP_CHERI] = "cheri_fault",
+    [RISCV_EXCP_VERSION] = "cheri_version_fault",
 #endif
     // 32–47 Reserved for future standard use
     // 48-63 Reserved for custom use

--- a/target/riscv/cpu.h
+++ b/target/riscv/cpu.h
@@ -91,6 +91,7 @@ enum {
     TRANSLATE_G_STAGE_FAIL,
 #if defined(TARGET_CHERI) && !defined(TARGET_RISCV32)
     TRANSLATE_CHERI_FAIL,
+    TRANSLATE_VERSION_FAIL,
 #endif
 };
 

--- a/target/riscv/cpu_bits.h
+++ b/target/riscv/cpu_bits.h
@@ -532,6 +532,7 @@
 #define PTE_D               0x080 /* Dirty */
 #define PTE_SOFT            0x300 /* Reserved for Software */
 #if defined(TARGET_CHERI) && !defined(TARGET_RISCV32)
+#define PTE_CWV             0x0400000000000000 /* Version write */
 #define PTE_CRG             0x0800000000000000 /* Cap Read Generation */
 #define PTE_CRM             0x1000000000000000 /* Cap Read Modifier */
 #define PTE_CD              0x2000000000000000 /* Cap Dirty */
@@ -575,6 +576,9 @@
 #define RISCV_EXCP_STORE_AMO_CAP_PAGE_FAULT      0x1b
 #endif
 #define RISCV_EXCP_CHERI                         0x1c
+#define RISCV_EXCP_VERSION                       0x1d
+/* XXX we don't currently distinguish betwen version mismatch and page fault but probably should ... */
+#define RISCV_EXCP_STORE_AMO_VER_PAGE_FAULT      RISCV_EXCP_VERSION
 #endif
 
 #define RISCV_EXCP_INT_FLAG                0x80000000

--- a/target/riscv/csr.c
+++ b/target/riscv/csr.c
@@ -435,6 +435,7 @@ static const target_ulong delegable_excps =
     (1ULL << (RISCV_EXCP_STORE_AMO_CAP_PAGE_FAULT)) |
 #endif
     (1ULL << (RISCV_EXCP_CHERI)) |
+    (1ULL << (RISCV_EXCP_VERSION)) |
 #endif
     0;
 static const target_ulong sstatus_v1_10_mask = SSTATUS_SIE | SSTATUS_SPIE |

--- a/target/riscv/insn32-cheri.decode
+++ b/target/riscv/insn32-cheri.decode
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Copyright (c) 2020 Alex Richardson
+# Copyright (c) 2021 Microsoft <robert.norton@microsoft.com>
 # All rights reserved.
 #
 # This software was developed by SRI International and the University of
@@ -37,7 +38,9 @@
 ### Three operand instructions
 # 0000000 unused
 cspecialrw  0000001  ..... ..... 000 ..... 1011011 @r
-# 0000010-0000111 unused
+csetversion 0000010  ..... ..... 000 ..... 1011011 @r
+camocdecversion 0000011  ..... ..... 000 ..... 1011011 @r
+# 0000100-0000111 unused
 csetbounds  0001000  ..... ..... 000 ..... 1011011 @r
 csetboundsexact 0001001  ..... ..... 000 ..... 1011011 @r
 # 0001010 unused
@@ -85,7 +88,10 @@ cgetaddr    1111111  01111 ..... 000 ..... 1011011 @r2
 # fpclear   1111111  10000 ..... 000 ..... 1011011 @r2
 csealentry  1111111  10001 ..... 000 ..... 1011011 @r2
 cloadtags   1111111  10010 ..... 000 ..... 1011011 @r2
+cgetversion 1111111  10011 ..... 000 ..... 1011011 @r2
 jalr_pcc    1111111  10100 ..... 000 ..... 1011011 @r2
+# cloadversions 1111111  10101 ..... 000 ..... 1011011 @r2
+cloadversion 1111111  10110 ..... 000 ..... 1011011 @r2
 
 
 
@@ -93,7 +99,8 @@ jalr_pcc    1111111  10100 ..... 000 ..... 1011011 @r2
 @r_2source ....... ..... .....   ... ..... ....... %rs2 %rs1
 
 ### Two operands (source1 and source2)
-cinvoke  1111110  ..... ..... 000 00001 1011011 @r_2source
+cinvoke        1111110  ..... ..... 000 00001 1011011 @r_2source
+cstoreversion  1111110  ..... ..... 000 00010 1011011 @r_2source
 
 
 ### Instructions with 12-bit immediates:

--- a/target/riscv/insn_trans/trans_cheri.c.inc
+++ b/target/riscv/insn_trans/trans_cheri.c.inc
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2020 Alex Richardson <Alexander.Richardson@cl.cam.ac.uk>
+ * Copyright (c) 2021 Microsoft <robert.norton@microsoft.com>
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -165,6 +166,8 @@ TRANSLATE_INT_CAP(cgettype)
 TRANSLATE_INT_CAP(cgetsealed)
 
 TRANSLATE_INT_CAP(cloadtags)
+TRANSLATE_INT_CAP(cgetversion)
+TRANSLATE_INT_CAP(cloadversion)
 
 // Two operand (int int)
 static inline bool trans_crrl(DisasContext *ctx, arg_crrl *a)
@@ -214,12 +217,14 @@ TRANSLATE_CAP_CAP_INT(csetbounds)
 TRANSLATE_CAP_CAP_INT(csetboundsexact)
 TRANSLATE_CAP_CAP_INT(csetflags)
 TRANSLATE_CAP_CAP_INT(csetoffset)
+TRANSLATE_CAP_CAP_INT(csetversion)
 
 // Three operand (int cap cap)
 TRANSLATE_INT_CAP_CAP(csub)
 TRANSLATE_INT_CAP_CAP(ctestsubset)
 TRANSLATE_INT_CAP_CAP(cseqx)
 TRANSLATE_INT_CAP_CAP(ctoptr)
+TRANSLATE_INT_CAP_CAP(camocdecversion)
 
 // CIncOffsetImm/CSetBoundsImm:
 typedef void(cheri_cap_cap_imm_helper)(TCGv_env, TCGv_i32, TCGv_i32, TCGv);
@@ -312,6 +317,17 @@ static inline bool trans_cinvoke(DisasContext *ctx, arg_cinvoke *a)
     lookup_and_goto_ptr(ctx);
     // PC has been updated -> exit translation block
     ctx->base.is_jmp = DISAS_NORETURN;
+    return true;
+}
+
+static inline bool trans_cstoreversion(DisasContext *ctx, arg_cstoreversion *a)
+{
+    TCGv_i32 base_regnum = tcg_const_i32(a->rs1);
+    TCGv gpr_value = tcg_temp_new();
+    gen_get_gpr(gpr_value, a->rs2);
+    gen_helper_cstoreversion(cpu_env, base_regnum, gpr_value);
+    tcg_temp_free_i32(base_regnum);
+    tcg_temp_free(gpr_value);
     return true;
 }
 
@@ -411,7 +427,7 @@ static bool gen_ddc_store(DisasContext *ctx, int rs1, int rs2, MemOp memop)
     return true;
 }
 
-/* Load Via Capability Register */
+/* Store Via Capability Register */
 static inline bool gen_cap_store_mem_idx(DisasContext *ctx, int32_t addr_regnum,
                                          int32_t val_regnum, target_long offset,
                                          int mem_idx, MemOp op)

--- a/target/riscv/pmp.h
+++ b/target/riscv/pmp.h
@@ -37,6 +37,8 @@ static inline pmp_priv_t access_type_to_pmp_priv(MMUAccessType at)
     case MMU_DATA_LOAD: return PMP_READ;
     case MMU_DATA_STORE: return PMP_WRITE;
     case MMU_INST_FETCH: return PMP_EXEC;
+    case MMU_VERSION_LOAD: return PMP_READ;
+    case MMU_VERSION_STORE: return PMP_WRITE;
     }
     abort();
 }


### PR DESCRIPTION
This PR is for discussion of qemu memory versioning implementation -- I do not necessarily expect it to be merged and certainly not in the current state.

The extensions are specified in a PRs to the [architecture document ](https://github.com/CTSRD-CHERI/cheri-architecture/pull/68) and on `mem_versions` branch of the [sail model](https://github.com/CTSRD-CHERI/sail-cheri-riscv/tree/mem_versions).