### PR TITLE
Updated cheri-compressed-cap without cap_register_t typedef

### DIFF
--- a/target/cheri-common/cheri-compressed-cap/.gitrepo
+++ b/target/cheri-common/cheri-compressed-cap/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/CTSRD-CHERI/cheri-compressed-cap
 	branch = master
-	commit = 142067b7436d2d454c2dfe97b389e8b04ced6881
+	commit = ba8fac547682dc129d5206944faf04987dda7126
 	parent = 23542fd653fa9a5e650852f706c727d41f4a5b91
 	cmdver = 0.4.1
 	method = rebase

--- a/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap.c
+++ b/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap.c
@@ -35,7 +35,7 @@
 uint64_t test(void) {
     uint64_t pesbt = 0x1234567;
     uint64_t cursor = 0x98765431;
-    cap_register_t result;
+    cc128_cap_t result;
     cc128_decompress_mem(pesbt, cursor, false, &result);
     uint64_t new_pesbt = cc128_compress_mem(&result);
     return cc128_is_representable_cap_exact(&result) + new_pesbt;

--- a/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap_common.h
+++ b/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap_common.h
@@ -672,6 +672,8 @@ static inline bool _cc_N(cap_sign_change)(_cc_addr_t addr1, _cc_addr_t addr2) {
 #ifdef CC_IS_MORELLO
     return ((addr1 ^ addr2) & (1ULL << (63 - MORELLO_FLAG_BITS)));
 #else
+    (void)addr1;
+    (void)addr2;
     return false;
 #endif
 }

--- a/target/cheri-common/cheri-compressed-cap/test/fuzz-decompress.cpp
+++ b/target/cheri-common/cheri-compressed-cap/test/fuzz-decompress.cpp
@@ -37,7 +37,7 @@
 #include "sail_wrapper.h"
 #include "FuzzedDataProvider.h"
 
-static void dump_cap_fields(const cap_register_t& result) {
+static void dump_cap_fields(const cc128_cap_t& result) {
     fprintf(stderr, "Permissions: 0x%" PRIx32 "\n", result.cr_perms); // TODO: decode perms
     fprintf(stderr, "User Perms:  0x%" PRIx32 "\n", result.cr_uperms);
     fprintf(stderr, "Base:        0x%016" PRIx64 "\n", result.cr_base);
@@ -79,8 +79,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     FuzzedDataProvider fuzzData(data, size);
     uint64_t pesbt = fuzzData.ConsumeIntegral<uint64_t>();
     uint64_t cursor = fuzzData.ConsumeIntegral<uint64_t>();
-    cap_register_t result;
-    cap_register_t sail_result;
+    cc128_cap_t result;
+    cc128_cap_t sail_result;
     memset(&result, 0, sizeof(result));
     memset(&sail_result, 0, sizeof(sail_result));
     cc128_decompress_mem(pesbt, cursor, false, &result);

--- a/target/cheri-common/cheri-compressed-cap/test/simple_test.cpp
+++ b/target/cheri-common/cheri-compressed-cap/test/simple_test.cpp
@@ -11,7 +11,7 @@
 
 TEST_CASE("Compressed NULL cap encodes to zeroes", "[nullcap]") {
     {
-        cap_register_t null_cap;
+        cc128_cap_t null_cap;
         memset(&null_cap, 0, sizeof(null_cap));
         null_cap.cr_otype = CC128_OTYPE_UNSEALED;
         null_cap._cr_top = CC128_NULL_TOP;
@@ -29,7 +29,7 @@ TEST_CASE("Compressed NULL cap encodes to zeroes", "[nullcap]") {
         fprintf(stderr, "NULL ENCODED: 0x%llx\n", (long long)pesbt_without_xor);
         CHECK(pesbt_without_xor == CC128_NULL_XOR_MASK);
         check(pesbt, (uint64_t)0, "compressing NULL should result in zero pesbt");
-        cap_register_t decompressed;
+        cc128_cap_t decompressed;
         memset(&decompressed, 'b', sizeof(decompressed));
         cc128_decompress_mem(pesbt, 0, false, &decompressed);
         CHECK_FIELD(decompressed, base, 0);
@@ -44,7 +44,7 @@ TEST_CASE("Compressed NULL cap encodes to zeroes", "[nullcap]") {
     }
     {
         // Same for CHERI256
-        cap_register_t null_cap;
+        cc128_cap_t null_cap;
         memset(&null_cap, 0, sizeof(null_cap));
         null_cap.cr_otype = CC256_OTYPE_UNSEALED;
         null_cap._cr_top = CC256_NULL_TOP;
@@ -56,7 +56,7 @@ TEST_CASE("Compressed NULL cap encodes to zeroes", "[nullcap]") {
         check(buffer.u64s[3], (uint64_t)0, "compressing NULL should result in zero[3]");
 
         // compressing this result should give 0 again
-        cap_register_t decompressed;
+        cc128_cap_t decompressed;
         memset(&decompressed, 'b', sizeof(decompressed));
         decompress_256cap(buffer, &decompressed, false);
         CHECK_FIELD(decompressed, base, 0);
@@ -123,7 +123,7 @@ static void check_representable(uint64_t base, cc128_length_t length, uint64_t o
     // INFO("Length = " << length);
     // INFO("Expected to work = " << should_work);
     CAPTURE(base, length, should_work, ctx);
-    cap_register_t cap;
+    cc128_cap_t cap;
     memset(&cap, 0, sizeof(cap));
     cap.cr_base = base;
     cap._cr_cursor = base + offset;
@@ -134,7 +134,7 @@ static void check_representable(uint64_t base, cc128_length_t length, uint64_t o
     cap.cached_pesbt = cc128_compute_ebt(cap.cr_base, cap._cr_top, NULL, &exact_input);
     REQUIRE(exact_input == should_work);
     uint64_t compressed = cc128_compress_mem(&cap);
-    cap_register_t decompressed;
+    cc128_cap_t decompressed;
     memset(&decompressed, 0, sizeof(decompressed));
 
     cc128_decompress_mem(compressed, cap.cr_base + cap.offset(), cap.cr_tag, &decompressed);

--- a/target/cheri-common/cheri-compressed-cap/test/test_util.h
+++ b/target/cheri-common/cheri-compressed-cap/test/test_util.h
@@ -110,8 +110,8 @@ template <class Cap> static void dump_cap_fields(const Cap& result) {
     fprintf(stderr, "\n");
 }
 
-__attribute__((used)) static cap_register_t decompress_representable(uint64_t pesbt_already_xored, uint64_t cursor) {
-    cap_register_t result;
+__attribute__((used)) static cc128_cap_t decompress_representable(uint64_t pesbt_already_xored, uint64_t cursor) {
+    cc128_cap_t result;
     printf("Decompressing pesbt = %016" PRIx64 ", cursor = %016" PRIx64 "\n", pesbt_already_xored, cursor);
     cc128_decompress_raw(pesbt_already_xored, cursor, false, &result);
     dump_cap_fields(result);
@@ -122,7 +122,7 @@ __attribute__((used)) static cap_register_t decompress_representable(uint64_t pe
     return result;
 }
 
-inline cap_register_t make_max_perms_cap(uint64_t base, uint64_t offset, cc128_length_t length) {
+inline cc128_cap_t make_max_perms_cap(uint64_t base, uint64_t offset, cc128_length_t length) {
     return cc128_make_max_perms_cap(base, offset, length);
 }
 

--- a/target/cheri-common/cheri_defs.h
+++ b/target/cheri-common/cheri_defs.h
@@ -119,6 +119,7 @@
 #  error "Unsupported capability type"
 #endif
 
+typedef cc128_cap_t cap_register_t;
 typedef signed __int128 cap_offset_t;
 typedef unsigned __int128 cap_length_t;
 


### PR DESCRIPTION
Tiny submodule change in order to support CHERI-64.
