### PR TITLE
Add printf-like instruction logging function

### DIFF
--- a/accel/tcg/log_instr.c
+++ b/accel/tcg/log_instr.c
@@ -43,6 +43,9 @@
 #include "exec/log_instr.h"
 #include "exec/memop.h"
 #include "disas/disas.h"
+#include "exec/translator.h"
+#include "tcg/tcg.h"
+#include "tcg/tcg-op.h"
 
 /*
  * CHERI common instruction logging.
@@ -936,6 +939,12 @@ void qemu_log_instr_reg(CPUArchState *env, const char *reg_name, target_ulong va
     g_array_append_val(iinfo->regs, r);
 }
 
+void helper_qemu_log_instr_reg(CPUArchState *env, const void *reg_name,
+                               target_ulong value)
+{
+    qemu_log_instr_reg(env, (const char *)reg_name, value);
+}
+
 #ifdef TARGET_CHERI
 void qemu_log_instr_cap(CPUArchState *env, const char *reg_name,
                          const cap_register_t *cr)
@@ -947,6 +956,13 @@ void qemu_log_instr_cap(CPUArchState *env, const char *reg_name,
     r.name = reg_name;
     r.cap = *cr;
     g_array_append_val(iinfo->regs, r);
+}
+
+void helper_qemu_log_instr_cap(CPUArchState *env, const void *reg_name,
+                               const void *cr)
+{
+    if (qemu_log_instr_check_enabled(env))
+        qemu_log_instr_cap(env, reg_name, cr);
 }
 
 void qemu_log_instr_cap_int(CPUArchState *env, const char *reg_name,
@@ -1081,6 +1097,359 @@ void qemu_log_instr_extra(CPUArchState *env, const char *msg, ...)
     va_end(va);
 }
 
+/*
+ *  A printf that takes an array of argments unioned of all possible argument
+ * types. Because we cant edit a VA_LIST, and we don't want the exponential blow
+ * up of handling all combinations of types, we will bounce individual string
+ * sections split in the fmt string to another buffer, then switch on all
+ * possible types.
+ */
+static void g_string_append_printf_union_args(GString *string, const char *fmt,
+                                              qemu_log_arg_t *args)
+{
+
+/* So Clang will not complain about the non-literal format. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#pragma GCC diagnostic ignored "-Wformat-security"
+
+    char bounce_buf[256];
+
+    size_t i = 0;
+    bool format = false;
+    char c;
+    bool is_short, is_long, is_long_long;
+    while ((c = bounce_buf[i++] = *fmt++)) {
+        assert(i != sizeof(bounce_buf));
+        if (!format) {
+            /*
+             * A safe amount under the maximum size. An (illegally) wrong format
+             * will cause the assert to be hit, but is a bug on the caller's
+             * part.
+             */
+            if (i >= (sizeof(bounce_buf) - 10)) {
+                bounce_buf[i] = '\0';
+                g_string_append_printf(string, bounce_buf);
+                i = 0;
+            }
+            format = c == '%';
+            is_short = is_long = is_long_long = false;
+            continue;
+        }
+        bounce_buf[i] = '\0';
+        switch (c) {
+        case 'c':
+            g_string_append_printf(string, bounce_buf, (args++)->charv);
+            format = false;
+            i = 0;
+            break;
+        case 'd':
+        case 'i':
+            if (is_long_long) {
+                g_string_append_printf(string, bounce_buf, (args++)->longlongv);
+            } else if (is_long) {
+                g_string_append_printf(string, bounce_buf, (args++)->longv);
+            } else if (is_short) {
+                g_string_append_printf(string, bounce_buf, (args++)->shortv);
+            } else {
+                g_string_append_printf(string, bounce_buf, (args++)->intv);
+            }
+            format = false;
+            i = 0;
+            break;
+        case 'u':
+        case 'x':
+        case 'X':
+        case 'o':
+            if (is_long_long) {
+                g_string_append_printf(string, bounce_buf,
+                                       (args++)->ulonglongv);
+            } else if (is_long) {
+                g_string_append_printf(string, bounce_buf, (args++)->ulongv);
+            } else if (is_short) {
+                g_string_append_printf(string, bounce_buf, (args++)->ushortv);
+            } else {
+                g_string_append_printf(string, bounce_buf, (args++)->uintv);
+            }
+            format = false;
+            i = 0;
+            break;
+        case 'e':
+        case 'E':
+        case 'f':
+        case 'g':
+        case 'G':
+            if (is_long) {
+                g_string_append_printf(string, bounce_buf, (args++)->doublev);
+            } else {
+                g_string_append_printf(string, bounce_buf, (args++)->floatv);
+            }
+            format = false;
+            i = 0;
+            break;
+        case 's':
+        case 'p':
+            g_string_append_printf(string, bounce_buf, (args++)->ptrv);
+            format = false;
+            i = 0;
+            break;
+        case '%':
+            format = false;
+            break;
+        case 'h':
+            is_short = true;
+            break;
+        case 'l':
+            if (is_long) {
+                is_long_long = true;
+            }
+            is_long = true;
+            break;
+        default:
+            break;
+        }
+    }
+
+    g_string_append_printf(string, bounce_buf);
+
+#pragma clang diagnostic pop
+}
+
+TCGv_i64 qemu_log_printf_valid_entries;
+
+#define QEMU_PRINTF_LOG_OFFSET                                                 \
+    ((offsetof(ArchCPU, parent_obj) - offsetof(ArchCPU, env)) +                \
+     offsetof(struct CPUState, log_state.qemu_log_printf_buf))
+
+void qemu_log_printf_create_globals(void)
+{
+    qemu_log_printf_valid_entries = tcg_global_mem_new_i64(
+        cpu_env,
+        QEMU_PRINTF_LOG_OFFSET + offsetof(qemu_log_printf_buf_t, valid_entries),
+        "log_valids");
+}
+
+void qemu_log_gen_printf(DisasContextBase *base, const char *qemu_format,
+                         const char *fmt, ...)
+{
+
+    if (!qemu_base_logging_enabled(base)) {
+        return;
+    }
+
+    va_list args;
+    va_start(args, fmt);
+
+    size_t ndx = base->printf_used_ptr++;
+    assert(
+        ndx < QEMU_LOG_PRINTF_BUF_DEPTH &&
+        "Increase QEMU_LOG_PRINTF_FLUSH_BARRIER or QEMU_LOG_PRINTF_BUF_DEPTH");
+
+    size_t offset = QEMU_PRINTF_LOG_OFFSET +
+                    (sizeof(qemu_log_arg_t) * (QEMU_LOG_PRINTF_ARG_MAX * ndx));
+
+    int nargs = 0;
+    char t;
+
+    TCGv_i64 temp64 = tcg_temp_new_i64();
+    TCGv_i32 temp32 = tcg_temp_new_i32();
+
+    /* Store the format string out. */
+    size_t fmt_offset = QEMU_PRINTF_LOG_OFFSET +
+                        offsetof(qemu_log_printf_buf_t, fmts) +
+                        (sizeof(const char *) * ndx);
+
+#if UINTPTR_MAX == UINT32_MAX
+    tcg_gen_movi_i32(temp32, (uintptr_t)fmt);
+    tcg_gen_st_i32(temp32, cpu_env, fmt_offset);
+#else
+    tcg_gen_movi_i64(temp64, (uintptr_t)fmt);
+    tcg_gen_st_i64(temp64, cpu_env, fmt_offset);
+#endif
+
+    /* Mark this entry as valid. */
+    tcg_gen_movi_i64(temp64, (1ULL << ndx));
+    tcg_gen_or_i64(qemu_log_printf_valid_entries, qemu_log_printf_valid_entries,
+                   temp64);
+
+    /*
+     * Now process the qemu_format string and fmt string to generate tcg loads
+     * and stores.
+     */
+    while ((t = *qemu_format++)) {
+        assert(nargs != QEMU_LOG_PRINTF_ARG_MAX);
+        /*
+         * va_arg arguments are promoted according to standard promotion rules.
+         * floats promote to doubles, types shorter than int promote to int.
+         * Accessing va_arg with the wrong sign (but correct size) for
+         * everything else is dancing with UB. The spec says its is OK if both
+         * types could represent the value passed at runtime. However, as I am
+         * only going to _store_ the value, I'm 99% certain I am still fine just
+         * doing everything with one sign even when large magnitude values as
+         * passed.
+         */
+        char c;
+        bool format = false;
+        bool is_short, is_long, is_long_long, is_signed;
+
+        while ((c = *fmt++)) {
+            if (!format) {
+                format = c == '%';
+                if (format) {
+                    is_short = is_long = is_long_long = is_signed = false;
+                }
+                continue;
+            }
+            size_t arg_size = 0;
+            uint64_t arg_const;
+            switch (c) {
+            case 'c':
+                arg_size = sizeof(char);
+                if (t == 'c') {
+                    arg_const = (uint64_t)va_arg(args, int);
+                }
+                break;
+            case 'd':
+            case 'i':
+                is_signed = true;
+            case 'u':
+            case 'x':
+            case 'X':
+            case 'o':
+                if (is_long_long) {
+                    arg_size = sizeof(long long);
+                    if (t == 'c') {
+                        arg_const = (uint64_t)va_arg(args, long long);
+                    }
+                } else if (is_long) {
+                    arg_size = sizeof(long);
+                    if (t == 'c') {
+                        arg_const = (uint64_t)va_arg(args, long);
+                    }
+                } else if (is_short) {
+                    arg_size = sizeof(short);
+                    if (t == 'c') {
+                        arg_const = (uint64_t)va_arg(args, int);
+                    }
+                } else {
+                    arg_size = sizeof(int);
+                    if (t == 'c') {
+                        arg_const = (uint64_t)va_arg(args, int);
+                    }
+                }
+                format = false;
+                break;
+            case 'e':
+            case 'E':
+            case 'f':
+            case 'g':
+            case 'G':
+                if (is_long) {
+                    if (t == 'c') {
+                        arg_const = (uint64_t)va_arg(args, double);
+                    }
+                    arg_size = sizeof(double);
+                } else {
+                    if (t == 'c') {
+                        arg_const = (uint64_t)(float)va_arg(args, double);
+                    }
+                    arg_size = sizeof(float);
+                }
+                format = false;
+                break;
+            case 's':
+            case 'p':
+                arg_size = sizeof(void *);
+                /*
+                 * This does not break strict aliasing as long as only void*
+                 * and char* is passed.
+                 */
+                if (t == 'c') {
+                    arg_const = (uint64_t)va_arg(args, void *);
+                }
+            case '%':
+                format = false;
+                break;
+            case 'h':
+                is_short = true;
+                break;
+            case 'l':
+                if (is_long) {
+                    is_long_long = true;
+                }
+                is_long = true;
+                break;
+            default:
+                break;
+            }
+            if (arg_size != 0) {
+                /* Use 32-bit ops. */
+                if (arg_size <= 4) {
+                    TCGv_i32 t32;
+                    if (t == 'c') {
+                        t32 = temp32;
+                        tcg_gen_movi_i32(t32, (uint32_t)arg_const);
+                    } else if (t == 'w') {
+                        t32 = va_arg(args, TCGv_i32);
+                    } else {
+                        assert((t == 'd') && "bad QEMU format string");
+                        t32 = temp32;
+                        tcg_gen_extrl_i64_i32(t32, va_arg(args, TCGv_i64));
+                    }
+                    if (!t32) {
+                        t32 = temp32;
+                        tcg_gen_movi_i32(t32, 0);
+                    }
+                    switch (arg_size) {
+                    case 1:
+                        tcg_gen_st8_i32(t32, cpu_env, offset);
+                        break;
+                    case 2:
+                        tcg_gen_st16_i32(t32, cpu_env, offset);
+                        break;
+                    case 4:
+                        tcg_gen_st_i32(t32, cpu_env, offset);
+                        break;
+                    default:
+                        g_assert_not_reached();
+                    }
+                } else {
+                    assert(arg_size <= 8);
+                    /* Use 64-bit ops. */
+                    TCGv_i64 t64;
+                    if (t == 'c') {
+                        t64 = temp64;
+                        tcg_gen_movi_i64(t64, arg_const);
+                    } else if (t == 'w') {
+                        t64 = temp64;
+                        if (is_signed) {
+                            tcg_gen_ext_i32_i64(t64, va_arg(args, TCGv_i32));
+                        } else {
+                            tcg_gen_extu_i32_i64(t64, va_arg(args, TCGv_i32));
+                        }
+                    } else {
+                        assert((t == 'd') && "bad QEMU format string");
+                        t64 = va_arg(args, TCGv_i64);
+                    }
+                    if (!t64) {
+                        t64 = temp64;
+                        tcg_gen_movi_i64(t64, 0);
+                    }
+                    tcg_gen_st_i64(t64, cpu_env, offset);
+                }
+                offset += sizeof(qemu_log_arg_t);
+                break;
+            }
+        }
+        assert(c != 0 && "Format strings do not match");
+    }
+
+    va_end(args);
+
+    tcg_temp_free_i64(temp64);
+    tcg_temp_free_i32(temp32);
+}
+
 void qemu_log_instr_flush(CPUArchState *env)
 {
     cpu_log_instr_state_t *cpulog = get_cpu_log_state(env);
@@ -1100,6 +1469,32 @@ void qemu_log_instr_flush(CPUArchState *env)
 
 /* Instruction logging helpers */
 
+/* Dump out all the accumalated printf's */
+void helper_qemu_log_printf_dump(CPUArchState *env)
+{
+
+    tcg_debug_assert((QEMU_PRINTF_LOG_OFFSET + ((uintptr_t)env)) ==
+                     (uintptr_t)(&get_cpu_log_state(env)->qemu_log_printf_buf));
+
+    if (!qemu_log_instr_enabled(env)) {
+        return;
+    }
+
+    uint64_t valid = get_cpu_log_state(env)->qemu_log_printf_buf.valid_entries;
+
+    cpu_log_instr_info_t *iinfo = get_cpu_log_instr_info(env);
+
+    while (valid) {
+        size_t ndx = ctz64(valid);
+        valid ^= (1 << ndx);
+        qemu_log_arg_t *args =
+            get_cpu_log_state(env)->qemu_log_printf_buf.args +
+            (ndx * QEMU_LOG_PRINTF_ARG_MAX);
+        const char *fmt = get_cpu_log_state(env)->qemu_log_printf_buf.fmts[ndx];
+        g_string_append_printf_union_args(iinfo->txt_buffer, fmt, args);
+    }
+}
+
 /*
  * Enable or disable buffered logging that is triggered by the target
  * via qemu_log_instr_flush().
@@ -1108,10 +1503,11 @@ void helper_qemu_log_instr_buffered_mode(CPUArchState *env, uint32_t enable)
 {
     cpu_log_instr_state_t *cpulog = get_cpu_log_state(env);
 
-    if (enable) 
+    if (enable) {
         cpulog->flags |= QEMU_LOG_INSTR_FLAG_BUFFERED;
-    else
+    } else {
         cpulog->flags &= ~QEMU_LOG_INSTR_FLAG_BUFFERED;
+    }
 }
 
 /* Helper version of qemu_log_instr_flush */

--- a/accel/tcg/tcg-runtime.h
+++ b/accel/tcg/tcg-runtime.h
@@ -338,6 +338,7 @@ DEF_HELPER_FLAGS_5(gvec_bitsel, TCG_CALL_NO_RWG, void, ptr, ptr, ptr, ptr, i32)
 DEF_HELPER_FLAGS_2(qemu_log_instr_buffered_mode, TCG_CALL_NO_RWG, void, env, i32)
 DEF_HELPER_FLAGS_1(qemu_log_instr_buffer_flush, TCG_CALL_NO_RWG, void, env)
 DEF_HELPER_FLAGS_2(qemu_log_instr_start, TCG_CALL_NO_WG, void, env, tl)
+DEF_HELPER_FLAGS_1(qemu_log_printf_dump, TCG_CALL_NO_WG, void, env)
 DEF_HELPER_FLAGS_2(qemu_log_instr_user_start, TCG_CALL_NO_WG, void, env, tl)
 DEF_HELPER_FLAGS_2(qemu_log_instr_stop, TCG_CALL_NO_WG, void, env, tl)
 DEF_HELPER_FLAGS_0(qemu_log_instr_allcpu_start, TCG_CALL_NO_WG, void)
@@ -348,5 +349,9 @@ DEF_HELPER_FLAGS_4(qemu_log_instr_load64, TCG_CALL_NO_WG, void, env, cap_checked
 DEF_HELPER_FLAGS_4(qemu_log_instr_store64, TCG_CALL_NO_WG, void, env, cap_checked_ptr, i64, memop)
 DEF_HELPER_FLAGS_4(qemu_log_instr_load32, TCG_CALL_NO_WG, void, env, cap_checked_ptr, i32, memop)
 DEF_HELPER_FLAGS_4(qemu_log_instr_store32, TCG_CALL_NO_WG, void, env, cap_checked_ptr, i32, memop)
+DEF_HELPER_FLAGS_3(qemu_log_instr_reg, TCG_CALL_NO_WG, void, env, cptr, tl)
+#ifdef TARGET_CHERI
+DEF_HELPER_FLAGS_3(qemu_log_instr_cap, TCG_CALL_NO_WG, void, env, cptr, cptr)
+#endif
 DEF_HELPER_FLAGS_3(log_value, TCG_CALL_NO_WG, void, env, cptr, i64)
 #endif

--- a/accel/tcg/translator.c
+++ b/accel/tcg/translator.c
@@ -35,6 +35,27 @@ void translator_loop_temp_check(DisasContextBase *db)
     }
 }
 
+static void qemu_log_gen_printf_reset(DisasContextBase *base)
+{
+#ifdef CONFIG_TCG_LOG_INSTR
+    tcg_gen_movi_i64(qemu_log_printf_valid_entries, 0);
+    base->printf_used_ptr = 0;
+#endif
+}
+
+/* Should only be called in a place it cannot be skipped by a branch! */
+static void qemu_log_gen_printf_flush(DisasContextBase *base, bool force_flush)
+{
+#ifdef CONFIG_TCG_LOG_INSTR
+    if ((base->printf_used_ptr != 0) &&
+        (force_flush ||
+         (base->printf_used_ptr >= (QEMU_LOG_PRINTF_FLUSH_BARRIER)))) {
+        gen_helper_qemu_log_printf_dump(cpu_env);
+        qemu_log_gen_printf_reset(base);
+    }
+#endif
+}
+
 void translator_loop(const TranslatorOps *ops, DisasContextBase *db,
                      CPUState *cpu, TranslationBlock *tb, int max_insns)
 {
@@ -116,6 +137,11 @@ void translator_loop(const TranslatorOps *ops, DisasContextBase *db,
 #ifdef CONFIG_TCG_LOG_INSTR
         /* Commit previous instruction */
         if (unlikely(log_instr_enabled)) {
+            /*
+             * TODO: As long as the string stays around, we could delay this
+             * till the end of a BB.
+             */
+            qemu_log_gen_printf_flush(db, true);
             gen_helper_qemu_log_instr_commit(cpu_env);
         }
 #endif
@@ -179,6 +205,13 @@ void translator_loop(const TranslatorOps *ops, DisasContextBase *db,
             break;
         }
     }
+
+#ifdef CONFIG_TCG_LOG_INSTR
+    /* Commit previous instruction */
+    if (unlikely(log_instr_enabled)) {
+        qemu_log_gen_printf_flush(db, true);
+    }
+#endif
 
     /* Emit code to exit the TB, as indicated by db->is_jmp.  */
     ops->tb_stop(db, cpu);

--- a/cpu.c
+++ b/cpu.c
@@ -36,6 +36,7 @@
 #include "sysemu/replay.h"
 #include "translate-all.h"
 #include "exec/log.h"
+#include "exec/log_instr.h"
 
 uintptr_t qemu_host_page_size;
 intptr_t qemu_host_page_mask;
@@ -181,6 +182,7 @@ void cpu_exec_realizefn(CPUState *cpu, Error **errp)
     if (tcg_enabled() && !tcg_target_initialized) {
         tcg_target_initialized = true;
         cc->tcg_initialize();
+        qemu_log_printf_create_globals();
     }
     tlb_init(cpu);
 

--- a/hw/arm/virt.c
+++ b/hw/arm/virt.c
@@ -1943,6 +1943,12 @@ static void machvirt_init(MachineState *machine)
         }
 
         qdev_realize(DEVICE(cpuobj), NULL, &error_fatal);
+
+        /* Start logging */
+#ifdef CONFIG_TCG_LOG_INSTR
+        qemu_log_instr_init(cs);
+#endif
+
         object_unref(cpuobj);
     }
     fdt_add_timer_nodes(vms);

--- a/include/exec/log_instr.h
+++ b/include/exec/log_instr.h
@@ -73,6 +73,14 @@
 
 #define _glue_args(...) , ## __VA_ARGS__
 
+#ifdef CONFIG_TCG_LOG_INSTR
+#define qemu_ctx_logging_enabled(ctx) unlikely(ctx->base.log_instr_enabled)
+#define qemu_base_logging_enabled(base) unlikely(base->log_instr_enabled)
+#else
+#define qemu_ctx_logging_enabled(ctx) false
+#define qemu_base_logging_enabled(base) false
+#endif
+
 /*
  * Helper to simplify checking for either instruction logging or
  * another loglevel enabled
@@ -128,6 +136,49 @@
     } while (0)
 
 #ifdef CONFIG_TCG_LOG_INSTR
+
+/* Format specifiers for TCGv and TCGv_ptr */
+#if TARGET_LONG_BITS == 64
+#define QLP_TCGV "d"
+#else
+#define QLP_TCGV "w"
+#endif
+#if UINTPTR_MAX == UINT32_MAX
+#define QLP_TCGP "w"
+#else
+#define QLP_TCGP "d"
+#endif
+
+/*
+ * Will generate TCG that will perform a printf to the extra logging info.
+ * Prints are batched until the end of an instruction
+ * TODO: This was actually designed to batch for an entire basic block, but
+ * sadly the string this would append to is cleared at the end of every
+ * instruction.
+ *
+ * The qemu_format is a string of the format ([c|w|d])*, The letter specifies
+ * whether the provided arguments are constant, words (TCGv_i32) or doubles
+ * (TCGv_i64). You should use provided macros QLP_ to deal with TCGv/TCGv_ptr.
+ * A NULL passed to a TCGv_* argument is interpreted as a constant 0.
+ * example usage: qemu_log_printf(ctx, QLP_TCGP QLP_TCGV "c", "%s, %c, %d\n",
+ * myTCGv_ptr, myTCGv, 7)
+ *
+ * WARN: Passed pointers MUST be const and live for the duration of the
+ * compiled basic block, as they are read when the prints are batched.
+ *
+ * WARN: This TCG should be reached either 0 or 1 times total for each
+ * invocation of the guest instruction. That is, you may have a TCG branch skip
+ * this generated TCG, but cannot have this in a TCG loop (although it may be
+ * part of a loop written in guest instructions, in which case you will get
+ * multiple prints as expected)
+ */
+
+struct DisasContextBase;
+void qemu_log_gen_printf(struct DisasContextBase *ctx, const char *qemu_format,
+                         const char *fmt, ...);
+struct TCGv_i64_d;
+extern struct TCGv_i64_d *qemu_log_printf_valid_entries;
+void qemu_log_printf_create_globals(void);
 
 /*
  * Request a flush of the TCG when changing loglevel outside of qemu_log_instr.
@@ -291,4 +342,6 @@ void qemu_log_instr_extra(CPUArchState *env, const char *msg, ...);
 #define	qemu_log_instr_env(...)
 #define	qemu_log_instr_extra(...)
 #define	qemu_log_instr_commit(...)
+#define qemu_log_gen_printf(...)
+#define qemu_log_printf_create_globals(...)
 #endif /* ! CONFIG_TCG_LOG_INSTR */

--- a/include/exec/translator.h
+++ b/include/exec/translator.h
@@ -81,6 +81,7 @@ typedef struct DisasContextBase {
     bool singlestep_enabled;
 #ifdef CONFIG_TCG_LOG_INSTR
     bool log_instr_enabled;
+    uint8_t printf_used_ptr;
 #endif
 } DisasContextBase;
 

--- a/include/qemu/log_instr.h
+++ b/include/qemu/log_instr.h
@@ -1,4 +1,4 @@
-/*-
+/*
  * SPDX-License-Identifier: BSD-2-Clause
  *
  * Copyright (c) 2020 Alfredo Mazzinghi
@@ -39,6 +39,14 @@
  */
 
 #ifdef CONFIG_TCG_LOG_INSTR
+
+/* Max printf args. */
+#define QEMU_LOG_PRINTF_ARG_MAX 8
+/* Max printf's before flush. */
+#define QEMU_LOG_PRINTF_BUF_DEPTH 32
+/* Early flush if buffer gets this full. */
+#define QEMU_LOG_PRINTF_FLUSH_BARRIER 32
+
 /*
  * Instruction logging format
  */
@@ -92,6 +100,28 @@ static inline qemu_log_instr_fmt_t qemu_log_instr_get_format()
 
 struct cpu_log_instr_info;
 
+typedef union {
+    char charv;
+    short shortv;
+    unsigned short ushortv;
+    int intv;
+    unsigned int uintv;
+    long longv;
+    unsigned long ulongv;
+    long long longlongv;
+    unsigned long long ulonglongv;
+    float floatv;
+    double doublev;
+    void *ptrv;
+} qemu_log_arg_t;
+
+typedef struct {
+    /* arguments to printf calls */
+    qemu_log_arg_t args[QEMU_LOG_PRINTF_ARG_MAX * QEMU_LOG_PRINTF_BUF_DEPTH];
+    const char *fmts[QEMU_LOG_PRINTF_BUF_DEPTH]; /* the printf fmts */
+    uint64_t valid_entries; /* bitmap of which entries are valid */
+} qemu_log_printf_buf_t;
+
 /*
  * Per-cpu logging state.
  */
@@ -114,6 +144,8 @@ typedef struct {
     size_t ring_head;
     /* Ring buffer index of the first entry to dump */
     size_t ring_tail;
+
+    qemu_log_printf_buf_t qemu_log_printf_buf;
 } cpu_log_instr_state_t;
 
 /*


### PR DESCRIPTION
Unlike qemu_log_instr_extra(), this can be called while translating and
avoids having to write a separate helper for every formatted instruction
tracing output.