### PR TITLE
Inlining for easy performance win

### DIFF
--- a/include/qemu/osdep.h
+++ b/include/qemu/osdep.h
@@ -310,6 +310,14 @@ extern int daemon(int, int);
 
 /* Check if n is a multiple of m */
 #define QEMU_IS_ALIGNED(n, m) (((n) % (m)) == 0)
+/* Check if n is a multiple of m (m must be a power of two).
+ * This can be use to generate more efficient code if the alignment argument
+ * is not a constant. */
+#if __has_builtin(__builtin_is_aligned)
+#define QEMU_IS_ALIGNED_P2(n, m) __builtin_is_aligned(n, m)
+#else
+#define QEMU_IS_ALIGNED_P2(n, m) (((n) & ((m) - 1)) == 0)
+#endif
 
 /* n-byte align pointer down */
 #define QEMU_ALIGN_PTR_DOWN(p, n) \

--- a/target/cheri-common/cheri-helper-utils.h
+++ b/target/cheri-common/cheri-helper-utils.h
@@ -249,14 +249,72 @@ static inline uint32_t perms_for_store(CPUArchState *env, uint32_t cs)
 typedef void QEMU_NORETURN (*unaligned_memaccess_handler)(CPUArchState *env,
                                                           target_ulong addr,
                                                           uintptr_t retpc);
-// Do all the permission and bounds checks for loads/stores on cbp.
-// Use perms_for_load() and perms_for_store() for required_perms.
-target_ulong cap_check_common_reg(uint32_t required_perms, CPUArchState *env,
-                                  uint32_t cb, target_ulong offset,
-                                  uint32_t size, uintptr_t _host_return_address,
-                                  const cap_register_t *cbp,
-                                  uint32_t alignment_required,
-                                  unaligned_memaccess_handler unaligned_handler);
+/* Do all the permission and bounds checks for loads/stores on cbp.
+ * Use perms_for_load() and perms_for_store() for required_perms.
+ *
+ * Note: This is marked as QEMU_ALWAYS_INLINE since profiling indicates that
+ * it has a large impact on overall QEMU speed (since it is called for every
+ * capability-based load/store). Not removing dead branches/propagating the
+ * constant alignment argument has a noticeable performance impact:
+ * Initially this function uses a modulo operation to check the alignment.
+ * This resulted in an x86 div instruction since the constant value was not
+ * known inside the function. Changing it to a bitwise-and (QEMU_IS_ALIGNED_P2)
+ * sped up the CheriBSD purecap kernel multi-user boot from ~314s to ~288s.
+ * However, without QEMU_ALWAYS_INLINE this function was still not being
+ * inlined so the alignment check was still using a non-constant argument
+ * and dead required_perms checks were still being performed every time.
+ * Adding QEMU_ALWAYS_INLINE seed up the boot from ~288s to ~278s.
+ */
+static inline QEMU_ALWAYS_INLINE target_ulong
+cap_check_common_reg(uint32_t required_perms, CPUArchState *env, uint32_t cb,
+                     target_ulong offset, uint32_t size,
+                     uintptr_t _host_return_address, const cap_register_t *cbp,
+                     uint32_t alignment_required,
+                     unaligned_memaccess_handler unaligned_handler)
+{
+#define MISSING_REQUIRED_PERM(X) ((required_perms & ~cbp->cr_perms) & (X))
+    if (!cbp->cr_tag) {
+        raise_cheri_exception(env, CapEx_TagViolation, cb);
+    } else if (!cap_is_unsealed(cbp)) {
+        raise_cheri_exception(env, CapEx_SealViolation, cb);
+    } else if (MISSING_REQUIRED_PERM(CAP_PERM_LOAD)) {
+        raise_cheri_exception(env, CapEx_PermitLoadViolation, cb);
+    } else if (MISSING_REQUIRED_PERM(CAP_PERM_STORE)) {
+        raise_cheri_exception(env, CapEx_PermitStoreViolation, cb);
+    } else if (MISSING_REQUIRED_PERM(CAP_PERM_STORE_CAP)) {
+        raise_cheri_exception(env, CapEx_PermitStoreCapViolation, cb);
+    } else if (MISSING_REQUIRED_PERM(CAP_PERM_STORE_LOCAL)) {
+        raise_cheri_exception(env, CapEx_PermitStoreLocalCapViolation, cb);
+    }
+#undef MISSING_REQUIRED_PERM
+
+    const target_ulong cursor = cap_get_cursor(cbp);
+    const target_ulong addr = cursor + (target_long)offset;
+    if (!cap_is_in_bounds(cbp, addr, size)) {
+        qemu_log_instr_or_mask_msg(
+            env, CPU_LOG_INT,
+            "Failed capability bounds check: offset=" TARGET_FMT_lx
+            " cursor=" TARGET_FMT_lx " addr=" TARGET_FMT_lx "\n",
+            offset, cursor, addr);
+        raise_cheri_exception(env, CapEx_LengthViolation, cb);
+    } else if (alignment_required &&
+               !QEMU_IS_ALIGNED_P2(addr, alignment_required)) {
+        if (unaligned_handler) {
+            unaligned_handler(env, addr, _host_return_address);
+        }
+#if defined(TARGET_MIPS) && defined(CHERI_UNALIGNED)
+        const char *access_type =
+            (required_perms == (CAP_PERM_STORE | CAP_PERM_LOAD))
+                ? "RMW"
+                : ((required_perms == CAP_PERM_STORE) ? "store" : "load");
+        qemu_maybe_log_instr_extra(env,
+                                   "Allowing unaligned %d-byte %s of "
+                                   "address 0x%" PRIx64 "\n",
+                                   size, access_type, addr);
+#endif
+    }
+    return addr;
+}
 
 // Helper for RISCV AMOSWAP
 bool load_cap_from_memory_raw(CPUArchState *env, target_ulong *pesbt,

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -1044,7 +1044,8 @@ target_ulong cap_check_common_reg(uint32_t required_perms, CPUArchState *env,
             " cursor=" TARGET_FMT_lx " addr=" TARGET_FMT_lx "\n",
             offset, cursor, addr);
         raise_cheri_exception(env, CapEx_LengthViolation, cb);
-    } else if (!QEMU_IS_ALIGNED(addr, alignment_required)) {
+    } else if (alignment_required &&
+               !QEMU_IS_ALIGNED_P2(addr, alignment_required)) {
         if (unaligned_handler) {
             unaligned_handler(env, addr, _host_return_address);
         }


### PR DESCRIPTION
Looking at `perf` traces, cap_check_common_reg showed up in hot paths and was using an x86 `div` instruction due to lack of constant propagation. It also wasn't stripping dead permission checks. This PR marks the function as QEMU_ALWAYS_INLINE and adds a QEMU_IS_ALIGNED_P2() to deal with unknown power-of-two alignment.

This is 1.14 times faster than the #150 performance baseline (which is almost twice as fast as the current `dev` branch).
```
alr48@waltham:/local/scratch/alr48/cheri/cheribsd(dev u=)> hyperfine -L qemu /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.p2-always-inline,/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.softtlb '/home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd {qemu} --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest' -m 3
Benchmark #1: /home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.p2-always-inline --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest
  Time (mean ± σ):     277.291 s ±  2.963 s    [User: 262.446 s, System: 5.949 s]
  Range (min … max):   274.706 s … 280.524 s    3 runs

Benchmark #2: /home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.softtlb --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest
  Time (mean ± σ):     315.843 s ±  1.212 s    [User: 305.962 s, System: 2.195 s]
  Range (min … max):   314.449 s … 316.648 s    3 runs

Summary
  '/home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.p2-always-inline --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest' ran
    1.14 ± 0.01 times faster than '/home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.softtlb --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest'
```