### PR TITLE
Speed up cincoffset_impl()

### DIFF
--- a/target/cheri-common/cheri-lazy-capregs.h
+++ b/target/cheri-common/cheri-lazy-capregs.h
@@ -236,6 +236,37 @@ static inline void update_capreg(CPUArchState *env, unsigned regnum,
     cheri_log_instr_changed_gp_capreg(env, regnum, target);
 }
 
+
+/*
+ * This function can be called to avoid copying a full cap_register_t when
+ * updating a capability register inplace.
+ * Note: new_cursor must be representable given the bounds of source_cap;
+ * see addr_in_cap_bounds()/is_representable_cap_with_addr().
+ */
+static inline void update_capreg_cursor_from(CPUArchState *env, unsigned regnum,
+                                             const cap_register_t *source_cap,
+                                             unsigned source_regnum,
+                                             const target_ulong new_cursor)
+{
+    if (unlikely(regnum == NULL_CAPREG_INDEX)) {
+        return;
+    }
+    GPCapRegs *gpcrs = cheri_get_gpcrs(env);
+    cap_register_t *target = &gpcrs->decompressed[regnum];
+    cheri_debug_assert(get_capreg_state(gpcrs, source_regnum) ==
+                       CREG_FULLY_DECOMPRESSED);
+    cheri_debug_assert(is_representable_cap_with_addr(source_cap, new_cursor));
+    if (regnum != source_regnum) {
+        *target = *source_cap;
+        set_capreg_state(gpcrs, regnum, CREG_FULLY_DECOMPRESSED);
+    }
+    /* When updating in-place, we can avoid copying. */
+    target->_cr_cursor = new_cursor;
+    sanity_check_capreg(gpcrs, regnum);
+    rvfi_changed_capreg(env, regnum, target->_cr_cursor);
+    cheri_log_instr_changed_gp_capreg(env, regnum, target);
+}
+
 static inline void update_compressed_capreg(CPUArchState *env, unsigned regnum,
                                             target_ulong pesbt, bool tag,
                                             target_ulong cursor)

--- a/target/cheri-common/cheri_utils.h
+++ b/target/cheri-common/cheri_utils.h
@@ -137,13 +137,20 @@ static inline bool cap_is_in_bounds(const cap_register_t* c, target_ulong addr, 
     return true;
 }
 
-static inline bool cap_cursor_in_bounds(const cap_register_t *c)
+static inline QEMU_ALWAYS_INLINE bool
+addr_in_cap_bounds(const cap_register_t *c, target_ulong addr)
 {
-    return cap_get_cursor(c) >= cap_get_base(c) &&
-           cap_get_cursor(c) < cap_get_top_full(c);
+    return addr >= cap_get_base(c) && addr < cap_get_top_full(c);
 }
 
-static inline bool cap_has_perms(const cap_register_t* reg, uint32_t perms)
+static inline QEMU_ALWAYS_INLINE bool
+cap_cursor_in_bounds(const cap_register_t *c)
+{
+    return addr_in_cap_bounds(c, cap_get_cursor(c));
+}
+
+static inline QEMU_ALWAYS_INLINE bool cap_has_perms(const cap_register_t *reg,
+                                                    uint32_t perms)
 {
     return (reg->cr_perms & perms) == perms;
 }
@@ -269,12 +276,12 @@ static inline void set_max_perms_capability(cap_register_t *crp, target_ulong cu
     *crp = CAP_cc(make_max_perms_cap)(0, cursor, CAP_MAX_TOP);
 }
 
-static inline bool
+static inline QEMU_ALWAYS_INLINE bool
 is_representable_cap_with_addr(const cap_register_t* cap, target_ulong new_addr)
 {
     return CAP_cc(is_representable_with_addr)(cap, new_addr);
 }
-static inline bool
+static inline QEMU_ALWAYS_INLINE bool
 is_representable_cap_when_sealed_with_addr(const cap_register_t* cap, target_ulong new_addr)
 {
     cheri_debug_assert(cap_is_unsealed(cap));

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -689,18 +689,15 @@ DEFINE_CHERI_STAT(csetoffset);
 DEFINE_CHERI_STAT(csetaddr);
 DEFINE_CHERI_STAT(candaddr);
 DEFINE_CHERI_STAT(cfromptr);
+#endif
 
 static inline QEMU_ALWAYS_INLINE void
 cincoffset_impl(CPUArchState *env, uint32_t cd, uint32_t cb, target_ulong rt,
-                uintptr_t retpc, struct oob_stats_info *oob_info)
+                uintptr_t retpc,
+                struct oob_stats_info *oob_info ATTRIBUTE_UNUSED)
 {
+#ifdef DO_CHERI_STATISTICS
     oob_info->num_uses++;
-#else
-static inline QEMU_ALWAYS_INLINE void
-cincoffset_impl(CPUArchState *env, uint32_t cd, uint32_t cb, target_ulong rt,
-                uintptr_t retpc, void *dummy_arg)
-{
-    (void)dummy_arg;
 #endif
     const cap_register_t *cbp = get_readonly_capreg(env, cb);
     /*


### PR DESCRIPTION
Profiling with perf indicates that approximately 10% of the purecap
CHERI-RISC-V boot time is spent in helper_cincoffset. This commit adds
two optimizations:
- Inline the check for the common case (in-bounds update) to avoid a
  function call to the cheri-compressed-cap helpers
- Avoid copying the cap_register_t when source == dest and instead update
  the cr_cursor member directly. While this would also be safe if the
  capability becomes unrepresentable, we only if the result is also
  representable.

This results in a noticeable 1.07x speedup:

```
alr48@waltham:/local/scratch/alr48/cheri/cheribsd(dev u=)> hyperfine -L qemu /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.softtlb-new,/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri  '{qemu} -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -kernel /local/scratch/alr48/cheri/output/kernel-riscv64-purecap.CHERI-PURECAP-QEMU-MFS-ROOT -append init_path=/sbin/startup-benchmark.sh' -m 5
Benchmark #1: /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.softtlb-new -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -kernel /local/scratch/alr48/cheri/output/kernel-riscv64-purecap.CHERI-PURECAP-QEMU-MFS-ROOT -append init_path=/sbin/startup-benchmark.sh
  Time (mean ± σ):     11.107 s ±  0.057 s    [User: 10.727 s, System: 0.125 s]
  Range (min … max):   11.043 s … 11.160 s    5 runs

Benchmark #2: /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -kernel /local/scratch/alr48/cheri/output/kernel-riscv64-purecap.CHERI-PURECAP-QEMU-MFS-ROOT -append init_path=/sbin/startup-benchmark.sh
  Time (mean ± σ):     10.424 s ±  0.162 s    [User: 9.983 s, System: 0.118 s]
  Range (min … max):   10.264 s … 10.621 s    5 runs

Summary
  '/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -kernel /local/scratch/alr48/cheri/output/kernel-riscv64-purecap.CHERI-PURECAP-QEMU-MFS-ROOT -append init_path=/sbin/startup-benchmark.sh' ran
    1.07 ± 0.02 times faster than '/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.softtlb-new -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -kernel /local/scratch/alr48/cheri/output/kernel-riscv64-purecap.CHERI-PURECAP-QEMU-MFS-ROOT -append init_path=/sbin/startup-benchmark.sh'
```