### PR TITLE
Inline probe_access() into probe_{write,read,cap_write}

### DIFF
--- a/accel/tcg/cputlb.c
+++ b/accel/tcg/cputlb.c
@@ -1566,10 +1566,10 @@ static void notdirty_write(CPUState *cpu, vaddr mem_vaddr, unsigned size,
     }
 }
 
-static int probe_access_internal(CPUArchState *env, target_ulong addr,
-                                 int fault_size, MMUAccessType access_type,
-                                 int mmu_idx, bool nonfault,
-                                 void **phost, uintptr_t retaddr)
+static inline QEMU_ALWAYS_INLINE int
+probe_access_internal(CPUArchState *env, target_ulong addr, int fault_size,
+                      MMUAccessType access_type, int mmu_idx, bool nonfault,
+                      void **phost, uintptr_t retaddr)
 {
     uintptr_t index = tlb_index(env, mmu_idx, addr);
     CPUTLBEntry *entry = tlb_entry(env, mmu_idx, addr);
@@ -1662,8 +1662,9 @@ int probe_access_flags(CPUArchState *env, target_ulong addr,
     return flags;
 }
 
-void *probe_access(CPUArchState *env, target_ulong addr, int size,
-                   MMUAccessType access_type, int mmu_idx, uintptr_t retaddr)
+static inline QEMU_ALWAYS_INLINE void *
+probe_access_inlined(CPUArchState *env, target_ulong addr, int size,
+                     MMUAccessType access_type, int mmu_idx, uintptr_t retaddr)
 {
     void *host;
     int flags;
@@ -1702,6 +1703,8 @@ void *probe_access(CPUArchState *env, target_ulong addr, int size,
 
     return host;
 }
+
+#include "probe-access.inc.c"
 
 void *tlb_vaddr_to_host(CPUArchState *env, abi_ptr addr,
                         MMUAccessType access_type, int mmu_idx)

--- a/accel/tcg/probe-access.inc.c
+++ b/accel/tcg/probe-access.inc.c
@@ -1,0 +1,35 @@
+/*
+ * Note: Adding QEMU_ALWAYS_INLINE to probe_access() allows the conditions that
+ * depend on access_type to be constant-folded for the probe_read/probe_write
+ * helpers. Prior to this optimization about 16% of the total time booting a
+ * purecap CheriBSD kernel was spent inside probe_access() and of those 16% a
+ * large percentage was spent executing `switch(access_type).`
+ */
+void *probe_access(CPUArchState *env, target_ulong addr, int size,
+                   MMUAccessType access_type, int mmu_idx, uintptr_t ra)
+{
+    return probe_access_inlined(env, addr, size, access_type, mmu_idx, ra);
+}
+
+void *probe_write(CPUArchState *env, target_ulong addr, int size, int mmu_idx,
+                  uintptr_t retaddr)
+{
+    return probe_access_inlined(env, addr, size, MMU_DATA_STORE, mmu_idx,
+                                retaddr);
+}
+
+void *probe_read(CPUArchState *env, target_ulong addr, int size, int mmu_idx,
+                 uintptr_t retaddr)
+{
+    return probe_access_inlined(env, addr, size, MMU_DATA_LOAD, mmu_idx,
+                                retaddr);
+}
+
+#ifdef TARGET_CHERI
+void *probe_cap_write(CPUArchState *env, target_ulong addr, int size,
+                      int mmu_idx, uintptr_t retaddr)
+{
+    return probe_access_inlined(env, addr, size, MMU_DATA_CAP_STORE, mmu_idx,
+                                retaddr);
+}
+#endif

--- a/accel/tcg/user-exec.c
+++ b/accel/tcg/user-exec.c
@@ -190,9 +190,9 @@ static inline int handle_cpu_signal(uintptr_t pc, siginfo_t *info,
     g_assert_not_reached();
 }
 
-static int probe_access_internal(CPUArchState *env, target_ulong addr,
-                                 int fault_size, MMUAccessType access_type,
-                                 bool nonfault, uintptr_t ra)
+static QEMU_ALWAYS_INLINE int
+probe_access_internal(CPUArchState *env, target_ulong addr, int fault_size,
+                      MMUAccessType access_type, bool nonfault, uintptr_t ra)
 {
     int flags;
 
@@ -235,8 +235,9 @@ int probe_access_flags(CPUArchState *env, target_ulong addr,
     return flags;
 }
 
-void *probe_access(CPUArchState *env, target_ulong addr, int size,
-                   MMUAccessType access_type, int mmu_idx, uintptr_t ra)
+static inline QEMU_ALWAYS_INLINE void *
+probe_access_inlined(CPUArchState *env, target_ulong addr, int size,
+                     MMUAccessType access_type, int mmu_idx, uintptr_t ra)
 {
     int flags;
 
@@ -246,6 +247,8 @@ void *probe_access(CPUArchState *env, target_ulong addr, int size,
 
     return size ? g2h(addr) : NULL;
 }
+
+#include "probe-access.inc.c"
 
 #if defined(__i386__)
 

--- a/include/exec/exec-all.h
+++ b/include/exec/exec-all.h
@@ -393,24 +393,15 @@ tlb_flush_page_bits_by_mmuidx_all_cpus_synced(CPUState *cpu, target_ulong addr,
 void *probe_access(CPUArchState *env, target_ulong addr, int size,
                    MMUAccessType access_type, int mmu_idx, uintptr_t retaddr);
 
-static inline void *probe_write(CPUArchState *env, target_ulong addr, int size,
-                                int mmu_idx, uintptr_t retaddr)
-{
-    return probe_access(env, addr, size, MMU_DATA_STORE, mmu_idx, retaddr);
-}
+void *probe_write(CPUArchState *env, target_ulong addr, int size, int mmu_idx,
+                  uintptr_t retaddr);
 
-static inline void *probe_read(CPUArchState *env, target_ulong addr, int size,
-                               int mmu_idx, uintptr_t retaddr)
-{
-    return probe_access(env, addr, size, MMU_DATA_LOAD, mmu_idx, retaddr);
-}
+void *probe_read(CPUArchState *env, target_ulong addr, int size, int mmu_idx,
+                 uintptr_t retaddr);
 
 #ifdef TARGET_CHERI
-static inline void *probe_cap_write(CPUArchState *env, target_ulong addr,
-                                    int size, int mmu_idx, uintptr_t retaddr)
-{
-    return probe_access(env, addr, size, MMU_DATA_CAP_STORE, mmu_idx, retaddr);
-}
+void *probe_cap_write(CPUArchState *env, target_ulong addr, int size,
+                      int mmu_idx, uintptr_t retaddr);
 #endif
 
 /**

--- a/target/cheri-common/cheri_tagmem.c
+++ b/target/cheri-common/cheri_tagmem.c
@@ -611,11 +611,17 @@ void cheri_tag_set_many(CPUArchState *env, uint32_t tags, target_ulong vaddr,
 {
     tags &= CAP_TAG_GET_MANY_MASK;
 
-    MMUAccessType accessType = tags ? MMU_DATA_CAP_STORE : MMU_DATA_STORE;
-
     const int mmu_idx = cpu_mmu_index(env, false);
     store_capcause_reg(env, reg);
-    probe_access(env, vaddr, 1, accessType, mmu_idx, pc);
+    /*
+     * We call probe_(cap)_write rather than probe_access since the branches
+     * checking access_type can be eliminated.
+     */
+    if (tags) {
+        probe_cap_write(env, vaddr, 1, mmu_idx, pc);
+    } else {
+        probe_write(env, vaddr, 1, mmu_idx, pc);
+    }
     clear_capcause_reg(env);
 
     handle_paddr_return(write);


### PR DESCRIPTION
These functions are called extremely frequently when booting CheriBSD
(for every capability load/store), so the `switch (access_type)`
inside probe_access_internal() has a noticeable impact on overall
performance. By adding QEMU_ALWAYS_INLINE, we can avoid this switch
for all calls to probe_{write,read,cap_write}() and thereby speed up
the CheriBSD boot:

MFS_ROOT purecap:
```
alr48@waltham:/local/scratch/alr48/cheri/cheribsd(dev u=)> hyperfine -L qemu /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.inline-probe-functions,/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.no-inline-probe-functions  '{qemu} -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -kernel /local/scratch/alr48/cheri/output/kernel-riscv64-purecap.CHERI-PURECAP-QEMU-MFS-ROOT -append init_path=/sbin/startup-benchmark.sh' -m 5
Benchmark #1: /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.inline-probe-functions -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -kernel /local/scratch/alr48/cheri/output/kernel-riscv64-purecap.CHERI-PURECAP-QEMU-MFS-ROOT -append init_path=/sbin/startup-benchmark.sh
  Time (mean ± σ):      8.501 s ±  0.601 s    [User: 8.014 s, System: 0.121 s]
  Range (min … max):    7.999 s …  9.194 s    5 runs

Benchmark #2: /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.no-inline-probe-functions -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -kernel /local/scratch/alr48/cheri/output/kernel-riscv64-purecap.CHERI-PURECAP-QEMU-MFS-ROOT -append init_path=/sbin/startup-benchmark.sh
  Time (mean ± σ):      9.739 s ±  0.030 s    [User: 8.973 s, System: 0.206 s]
  Range (min … max):    9.707 s …  9.774 s    5 runs

Summary
  '/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.inline-probe-functions -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -kernel /local/scratch/alr48/cheri/output/kernel-riscv64-purecap.CHERI-PURECAP-QEMU-MFS-ROOT -append init_path=/sbin/startup-benchmark.sh' ran
    1.15 ± 0.08 times faster than '/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.no-inline-probe-functions -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -kernel /local/scratch/alr48/cheri/output/kernel-riscv64-purecap.CHERI-PURECAP-QEMU-MFS-ROOT -append init_path=/sbin/startup-benchmark.sh'
```

Full disk image purecap kernel:
```
alr48@waltham:/local/scratch/alr48/cheri/cheribsd(dev u=)> hyperfine -L qemu /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.inline-probe-functions,/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.no-inline-probe-functions '/home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd {qemu} --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest' -m 3
Benchmark #1: /home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.inline-probe-functions --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest
  Time (mean ± σ):     213.637 s ±  1.920 s    [User: 200.744 s, System: 2.847 s]
  Range (min … max):   211.734 s … 215.573 s    3 runs

Benchmark #2: /home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.no-inline-probe-functions --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest
  Time (mean ± σ):     243.621 s ±  3.036 s    [User: 230.935 s, System: 2.485 s]
  Range (min … max):   240.935 s … 246.915 s    3 runs

Summary
  '/home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.inline-probe-functions --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest' ran
    1.14 ± 0.02 times faster than '/home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.no-inline-probe-functions --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest'
```