### PR TITLE
CLoadTags fixes

### DIFF
--- a/target/cheri-common/cheri-helper-common.h
+++ b/target/cheri-common/cheri-helper-common.h
@@ -112,3 +112,4 @@ DEF_HELPER_4(store_cap_via_cap, void, env, i32, i32, tl)
 
 // Misc
 DEF_HELPER_2(decompress_cap, void, env, i32)
+DEF_HELPER_2(cloadtags, tl, env, i32)

--- a/target/cheri-common/cheri-helper-utils.h
+++ b/target/cheri-common/cheri-helper-utils.h
@@ -279,6 +279,8 @@ cap_check_common_reg(uint32_t required_perms, CPUArchState *env, uint32_t cb,
         raise_cheri_exception(env, CapEx_SealViolation, cb);
     } else if (MISSING_REQUIRED_PERM(CAP_PERM_LOAD)) {
         raise_cheri_exception(env, CapEx_PermitLoadViolation, cb);
+    } else if (MISSING_REQUIRED_PERM(CAP_PERM_LOAD_CAP)) {
+        raise_cheri_exception(env, CapEx_PermitLoadCapViolation, cb);
     } else if (MISSING_REQUIRED_PERM(CAP_PERM_STORE)) {
         raise_cheri_exception(env, CapEx_PermitStoreViolation, cb);
     } else if (MISSING_REQUIRED_PERM(CAP_PERM_STORE_CAP)) {

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -1275,6 +1275,22 @@ void store_cap_to_memory(CPUArchState *env, uint32_t cs,
 #endif
 }
 
+target_ulong CHERI_HELPER_IMPL(cloadtags(CPUArchState *env, uint32_t cb))
+{
+    static const uint32_t perms = CAP_PERM_LOAD | CAP_PERM_LOAD_CAP;
+    static const size_t ncaps = 1 << CAP_TAG_GET_MANY_SHFT;
+    static const uint32_t sizealign = ncaps * CHERI_CAP_SIZE;
+
+    GET_HOST_RETPC();
+    const cap_register_t *cbp = get_capreg_0_is_ddc(env, cb);
+
+    const target_ulong addr = cap_check_common_reg(
+        perms, env, cb, 0, sizealign, _host_return_address, cbp, sizealign,
+        raise_unaligned_load_exception);
+
+    return (target_ulong)cheri_tag_get_many(env, addr, cb, NULL, GETPC());
+}
+
 QEMU_NORETURN static inline void raise_pcc_fault(CPUArchState *env,
                                                  CheriCapExcCause cause,
                                                  uintptr_t _host_return_address)

--- a/target/mips/helper.h
+++ b/target/mips/helper.h
@@ -224,7 +224,6 @@ DEF_HELPER_4(cmovn, void, env, i32, i32, tl)
 
 DEF_HELPER_3(creadhwr, void, env, i32, i32)
 DEF_HELPER_3(cwritehwr, void, env, i32, i32)
-DEF_HELPER_3(cloadtags, tl, env, i32, cap_checked_ptr)
 
 DEF_HELPER_3(ceq, tl, env, i32, i32)
 DEF_HELPER_3(cne, tl, env, i32, i32)

--- a/target/mips/op_helper_cheri.c
+++ b/target/mips/op_helper_cheri.c
@@ -290,27 +290,6 @@ void CHERI_HELPER_IMPL(creturn(CPUArchState *env)) {
     do_raise_c2_exception_noreg(env, CapEx_ReturnTrap, GETPC());
 }
 
-target_ulong CHERI_HELPER_IMPL(cloadtags(CPUArchState *env, uint32_t cb, uint64_t cbcursor))
-{
-    GET_HOST_RETPC();
-    const cap_register_t *cbp = get_capreg_0_is_ddc(env, cb);
-
-    if (!cbp->cr_tag) {
-        raise_cheri_exception(env, CapEx_TagViolation, cb);
-    } else if (is_cap_sealed(cbp)) {
-        raise_cheri_exception(env, CapEx_SealViolation, cb);
-    } else if (!(cbp->cr_perms & CAP_PERM_LOAD)) {
-        raise_cheri_exception(env, CapEx_PermitLoadViolation, cb);
-    } else if (!(cbp->cr_perms & CAP_PERM_LOAD_CAP)) {
-        raise_cheri_exception(env, CapEx_PermitLoadCapViolation, cb);
-    } else if ((cbcursor & (8 * CHERI_CAP_SIZE - 1)) != 0) {
-        do_raise_c0_exception(env, EXCP_AdEL, cbcursor);
-    } else {
-       return (target_ulong)cheri_tag_get_many(env, cbcursor, cb, NULL, GETPC());
-    }
-    return 0;
-}
-
 target_ulong CHERI_HELPER_IMPL(cgetcause(CPUArchState *env))
 {
     /*

--- a/target/mips/translate_cheri.c
+++ b/target/mips/translate_cheri.c
@@ -295,16 +295,10 @@ static inline void generate_cloadtags(DisasContext *ctx, int32_t rd, int32_t cb)
     TCGv_i32 tcb = tcg_const_i32(cb);
     TCGv_cap_checked_ptr tcbc  = tcg_temp_new_cap_checked();
     TCGv ttags = tcg_temp_new();
-    TCGv toffset = tcg_const_tl(0);
-    TCGv_i32 tlen = tcg_const_i32(128); // XXX cache line width
-
-    gen_helper_cap_load_check(tcbc, cpu_env, tcb, toffset, tlen);
-    tcg_temp_free_i32(tlen);
-    tcg_temp_free(toffset);
 
     tcg_gen_mb(TCG_MO_LD_LD | TCG_MO_ST_LD | TCG_BAR_SC);
 
-    gen_helper_cloadtags(ttags, cpu_env, tcb, tcbc);
+    gen_helper_cloadtags(ttags, cpu_env, tcb);
     tcg_gen_movi_i32(tcb, MO_TEQ);
 #ifdef CONFIG_TCG_LOG_INSTR
     gen_helper_qemu_log_instr_load64(cpu_env, tcbc, ttags, tcb); // FIXME: not really correct

--- a/target/riscv/helper.h
+++ b/target/riscv/helper.h
@@ -77,7 +77,6 @@ DEF_HELPER_3(lr_c_cap, void, env, i32, i32)
 DEF_HELPER_3(sc_c_modedep, tl, env, i32, i32)
 DEF_HELPER_3(sc_c_ddc, tl, env, i32, i32)
 DEF_HELPER_3(sc_c_cap, tl, env, i32, i32)
-DEF_HELPER_2(cloadtags, tl, env, i32)
 #endif
 
 #ifdef CONFIG_TCG_LOG_INSTR

--- a/target/riscv/op_helper_cheri.c
+++ b/target/riscv/op_helper_cheri.c
@@ -444,28 +444,3 @@ target_ulong HELPER(sc_c_cap)(CPUArchState *env, uint32_t addr_reg, uint32_t val
 {
     return sc_c_impl(env, addr_reg, val_reg, /*offset=*/0, GETPC());
 }
-
-target_ulong HELPER(cloadtags)(CPUArchState *env, uint32_t cb)
-{
-    GET_HOST_RETPC();
-    const cap_register_t *cbp = get_capreg_0_is_ddc(env, cb);
-    target_ulong cursor = cap_get_cursor(cbp);
-
-    if (!cbp->cr_tag) {
-        raise_cheri_exception(env, CapEx_TagViolation, cb);
-    } else if (!cap_is_unsealed(cbp)) {
-        raise_cheri_exception(env, CapEx_SealViolation, cb);
-    } else if (!(cbp->cr_perms & CAP_PERM_LOAD)) {
-        raise_cheri_exception(env, CapEx_PermitLoadViolation, cb);
-    } else if (!(cbp->cr_perms & CAP_PERM_LOAD_CAP)) {
-        /* CLoadTags raises an exception rather than report 0 */
-        raise_cheri_exception(env, CapEx_PermitLoadCapViolation, cb);
-    } else if (!cap_is_in_bounds(cbp, cursor, 8 * CHERI_CAP_SIZE)) {
-        raise_cheri_exception(env, CapEx_LengthViolation, cb);
-    } else if ((cursor & (8 * CHERI_CAP_SIZE - 1)) != 0) {
-        raise_unaligned_load_exception(env, cursor, GETPC());
-    } else {
-       return (target_ulong)cheri_tag_get_many(env, cursor, cb, NULL, GETPC());
-    }
-    return 0;
-}


### PR DESCRIPTION
Both RISC-V and MIPS had hard-coded the stride to 8, which was missed when
CAP_TAG_GET_MANY_SHFT was recently changed.

MIPS failed to check that the entire region was within the auth cap bounds