### PR TITLE
Basic multi-threaded capability tag implementation

### DIFF
--- a/accel/tcg/cpu-exec.c
+++ b/accel/tcg/cpu-exec.c
@@ -749,8 +749,6 @@ int cpu_exec(CPUState *cpu)
     /* prepare setjmp context for exception handling */
     if (sigsetjmp(cpu->jmp_env, 0) != 0) {
 
-        cheri_tag_locks_exception_thrown(cpu);
-
 #if defined(__clang__) || !QEMU_GNUC_PREREQ(4, 6)
         /* Some compilers wrongly smash all local variables after
          * siglongjmp. There were bug reports for gcc 4.5.0 and clang.
@@ -766,6 +764,9 @@ int cpu_exec(CPUState *cpu)
 #ifndef CONFIG_SOFTMMU
         tcg_debug_assert(!have_mmap_lock());
 #endif
+
+        cheri_tag_locks_exception_thrown(cpu);
+
         if (qemu_mutex_iothread_locked()) {
             qemu_mutex_unlock_iothread();
         }

--- a/accel/tcg/cpu-exec.c
+++ b/accel/tcg/cpu-exec.c
@@ -40,6 +40,7 @@
 #include "exec/cpu-all.h"
 #include "sysemu/cpu-timers.h"
 #include "sysemu/replay.h"
+#include "cheri_tagmem.h"
 
 /* -icount align implementation. */
 
@@ -278,6 +279,7 @@ void cpu_exec_step_atomic(CPUState *cpu)
         cpu_tb_exec(cpu, tb, &tb_exit);
         cc->cpu_exec_exit(cpu);
     } else {
+        cheri_tag_locks_exception_thrown(cpu);
         /*
          * The mmap_lock is dropped by tb_gen_code if it runs out of
          * memory.
@@ -746,6 +748,9 @@ int cpu_exec(CPUState *cpu)
 
     /* prepare setjmp context for exception handling */
     if (sigsetjmp(cpu->jmp_env, 0) != 0) {
+
+        cheri_tag_locks_exception_thrown(cpu);
+
 #if defined(__clang__) || !QEMU_GNUC_PREREQ(4, 6)
         /* Some compilers wrongly smash all local variables after
          * siglongjmp. There were bug reports for gcc 4.5.0 and clang.

--- a/accel/tcg/tcg-runtime.h
+++ b/accel/tcg/tcg-runtime.h
@@ -153,11 +153,29 @@ DEF_HELPER_3(ddc_check_bounds_store, void, env, tl, tl)
 #endif
 /* Same but relative to PCC */
 DEF_HELPER_3(pcc_check_bounds, void, env, tl, tl)
-/* Clear tags due to a store. Only call this after the store succeeded. */
+
+/* TODO: Which of the following tag invalidates can be TCG_CALL_NO_RWG or
+ * TCG_CALL_NO_WG? tags are not globals, so it should be all of them?
+ */
+
+/* Clear tags due to a store. Only calll this after the store succeeded. */
 DEF_HELPER_3(cheri_invalidate_tags, void, env, cap_checked_ptr, memop_idx)
+
 /* Clear tags due to a store, last argument is whether the store succeeded. */
 DEF_HELPER_4(cheri_invalidate_tags_condition, void, env, cap_checked_ptr,
              memop_idx, i32)
+
+DEF_HELPER_3(cheri_invalidate_lock_tags_start, void, env, cap_checked_ptr,
+             memop_idx)
+DEF_HELPER_3(cheri_invalidate_lock_tags_start_or_dummy, void, env,
+             cap_checked_ptr, memop_idx)
+DEF_HELPER_3(cheri_invalidate_lock_tags_end, void, env, cap_checked_ptr,
+             memop_idx)
+DEF_HELPER_4(cheri_invalidate_lock_tags_end_condition, void, env,
+             cap_checked_ptr, memop_idx, i32)
+
+DEF_HELPER_2(cheri_invalidate_lock_tags_assert_exist, void, env,
+             cap_checked_ptr)
 
 #endif
 

--- a/default-configs/targets/mips64cheri128-softmmu.mak
+++ b/default-configs/targets/mips64cheri128-softmmu.mak
@@ -6,5 +6,5 @@ INCLUDE_WORKAROUND=mips64-softmmu.mak
 # Same as mips64-softmmu.mak but with the extra mips64-cheri-c128.xml
 TARGET_XML_FILES=gdb-xml/mips64-cpu.xml gdb-xml/mips64-cp0.xml gdb-xml/mips64-fpu.xml gdb-xml/mips64-sys.xml gdb-xml/mips64-cheri-c128.xml
 TARGET_CHERI=y
-# Capability loads/stores+tagged memory don't work with MTTCG
-TARGET_SUPPORTS_MTTCG=n
+# Capability loads/stores+tagged memory work with MTTCG
+TARGET_SUPPORTS_MTTCG=y

--- a/default-configs/targets/mips64cheri128-softmmu.mak
+++ b/default-configs/targets/mips64cheri128-softmmu.mak
@@ -6,5 +6,3 @@ INCLUDE_WORKAROUND=mips64-softmmu.mak
 # Same as mips64-softmmu.mak but with the extra mips64-cheri-c128.xml
 TARGET_XML_FILES=gdb-xml/mips64-cpu.xml gdb-xml/mips64-cp0.xml gdb-xml/mips64-fpu.xml gdb-xml/mips64-sys.xml gdb-xml/mips64-cheri-c128.xml
 TARGET_CHERI=y
-# Capability loads/stores+tagged memory work with MTTCG
-TARGET_SUPPORTS_MTTCG=y

--- a/default-configs/targets/riscv32cheri-softmmu.mak
+++ b/default-configs/targets/riscv32cheri-softmmu.mak
@@ -6,5 +6,5 @@ INCLUDE_WORKAROUND=riscv32-softmmu.mak
 # Same as riscv32-softmmu.mak but with the extra riscv-32bit-cheri.xml
 TARGET_XML_FILES= gdb-xml/riscv-32bit-cpu.xml gdb-xml/riscv-32bit-fpu.xml gdb-xml/riscv-64bit-fpu.xml gdb-xml/riscv-32bit-csr.xml gdb-xml/riscv-32bit-virtual.xml gdb-xml/riscv-32bit-cheri.xml
 TARGET_CHERI=y
-# Capability loads/stores+tagged memory don't work with MTTCG
-TARGET_SUPPORTS_MTTCG=n
+# Capability loads/stores+tagged memory work with MTTCG
+TARGET_SUPPORTS_MTTCG=y

--- a/default-configs/targets/riscv32cheri-softmmu.mak
+++ b/default-configs/targets/riscv32cheri-softmmu.mak
@@ -6,5 +6,3 @@ INCLUDE_WORKAROUND=riscv32-softmmu.mak
 # Same as riscv32-softmmu.mak but with the extra riscv-32bit-cheri.xml
 TARGET_XML_FILES= gdb-xml/riscv-32bit-cpu.xml gdb-xml/riscv-32bit-fpu.xml gdb-xml/riscv-64bit-fpu.xml gdb-xml/riscv-32bit-csr.xml gdb-xml/riscv-32bit-virtual.xml gdb-xml/riscv-32bit-cheri.xml
 TARGET_CHERI=y
-# Capability loads/stores+tagged memory work with MTTCG
-TARGET_SUPPORTS_MTTCG=y

--- a/default-configs/targets/riscv64cheri-softmmu.mak
+++ b/default-configs/targets/riscv64cheri-softmmu.mak
@@ -6,5 +6,5 @@ INCLUDE_WORKAROUND=riscv64-softmmu.mak
 # Same as riscv64-softmmu.mak but with the extra riscv-64bit-cheri.xml
 TARGET_XML_FILES= gdb-xml/riscv-64bit-cpu.xml gdb-xml/riscv-32bit-fpu.xml gdb-xml/riscv-64bit-fpu.xml gdb-xml/riscv-64bit-csr.xml gdb-xml/riscv-64bit-virtual.xml gdb-xml/riscv-64bit-cheri.xml
 TARGET_CHERI=y
-# Capability loads/stores+tagged memory don't work with MTTCG
-TARGET_SUPPORTS_MTTCG=n
+# Capability loads/stores+tagged memory work with MTTCG
+TARGET_SUPPORTS_MTTCG=y

--- a/default-configs/targets/riscv64cheri-softmmu.mak
+++ b/default-configs/targets/riscv64cheri-softmmu.mak
@@ -6,5 +6,3 @@ INCLUDE_WORKAROUND=riscv64-softmmu.mak
 # Same as riscv64-softmmu.mak but with the extra riscv-64bit-cheri.xml
 TARGET_XML_FILES= gdb-xml/riscv-64bit-cpu.xml gdb-xml/riscv-32bit-fpu.xml gdb-xml/riscv-64bit-fpu.xml gdb-xml/riscv-64bit-csr.xml gdb-xml/riscv-64bit-virtual.xml gdb-xml/riscv-64bit-cheri.xml
 TARGET_CHERI=y
-# Capability loads/stores+tagged memory work with MTTCG
-TARGET_SUPPORTS_MTTCG=y

--- a/include/hw/core/cpu.h
+++ b/include/hw/core/cpu.h
@@ -479,9 +479,8 @@ struct CPUState {
     cpu_log_instr_state_t log_state;
 #endif
 
-    // TARGET_CHERI is poison in this context, so I guess we get these locks
-    // taking up space even if non CHERI. Yay C.
-    CHERI_EXCEPTION_LOCKS
+    /* TARGET_CHERI is poison in this context. This structure is small. */
+    cheri_exception_locks_t cheri_exception_locks;
 };
 
 typedef QTAILQ_HEAD(CPUTailQ, CPUState) CPUTailQ;

--- a/include/hw/core/cpu.h
+++ b/include/hw/core/cpu.h
@@ -20,6 +20,7 @@
 #ifndef QEMU_CPU_H
 #define QEMU_CPU_H
 
+#include "target/cheri-common/cheri_tagmem_ex_locks.h"
 #include "hw/qdev-core.h"
 #include "disas/dis-asm.h"
 #include "exec/hwaddr.h"
@@ -477,6 +478,10 @@ struct CPUState {
 #ifdef CONFIG_TCG_LOG_INSTR
     cpu_log_instr_state_t log_state;
 #endif
+
+    // TARGET_CHERI is poison in this context, so I guess we get these locks
+    // taking up space even if non CHERI. Yay C.
+    CHERI_EXCEPTION_LOCKS
 };
 
 typedef QTAILQ_HEAD(CPUTailQ, CPUState) CPUTailQ;

--- a/include/qemu/bitops.h
+++ b/include/qemu/bitops.h
@@ -595,6 +595,20 @@ static inline uint64_t byte_unpack_64(uint8_t x)
 }
 
 /**
+ * byte_unpack_64:
+ * @x Any 8-bit value
+ * @return A 64-bit value where each byte contains a single bit from x swapped.
+ */
+static inline uint64_t byte_unpack_swap_64(uint8_t x)
+{
+    uint64_t unpacked = x & 0xFF;
+    unpacked = (unpacked << 32) | (unpacked >> 4);
+    unpacked = (unpacked << 16) | (unpacked >> 2);
+    unpacked = (unpacked << 8) | (unpacked >> 1);
+    return (unpacked & 0x0101010101010101);
+}
+
+/**
  * byte_pack_64:
  * @x Any 64-bit value
  * @return A byte that contains the lowest bit of each byte in x
@@ -605,6 +619,20 @@ static inline uint8_t byte_pack_64(uint64_t x)
     x = (x >> 7) | x;
     x = (x >> 14) | x;
     x = (x >> 28) | x;
+    return (x & 0xFF);
+}
+
+/**
+ * byte_pack_64:
+ * @x Any 64-bit value
+ * @return A byte that contains the lowest bit of each byte in x reversed
+ */
+static inline uint8_t byte_pack_swap_64(uint64_t x)
+{
+    x &= 0x0101010101010101;
+    x = (x >> 8) | (x << 1);
+    x = (x >> 16) | (x << 2);
+    x = (x >> 32) | (x << 4);
     return (x & 0xFF);
 }
 
@@ -622,6 +650,19 @@ static inline uint32_t byte_unpack_32(uint8_t x)
 }
 
 /**
+ * byte_unpack_32:
+ * @x Any 8-bit value (top 4 bits ignored)
+ * @return A 32-bit value where each byte contains a single bit from x reserved.
+ */
+static inline uint32_t byte_unpack_swap_32(uint8_t x)
+{
+    uint32_t unpacked = x & 0xF;
+    unpacked = (unpacked << 16) | (unpacked >> 2);
+    unpacked = (unpacked << 8) | (unpacked >> 1);
+    return (unpacked & 0x01010101);
+}
+
+/**
  * byte_pack_32:
  * @x Any 32-bit value
  * @return A byte that contains the lowest bit of each byte in x
@@ -634,4 +675,16 @@ static inline uint8_t byte_pack_32(uint32_t x)
     return (x & 0xF);
 }
 
+/**
+ * byte_pack_32:
+ * @x Any 32-bit value
+ * @return A byte that contains the lowest bit of each byte in x reserved
+ */
+static inline uint8_t byte_pack_swap_32(uint32_t x)
+{
+    x &= 0x01010101;
+    x = (x >> 8) | (x << 1);
+    x = (x >> 16) | (x << 2);
+    return (x & 0xF);
+}
 #endif

--- a/target/arm/cheri_helper.c
+++ b/target/arm/cheri_helper.c
@@ -51,8 +51,8 @@ void helper_load_cap_via_cap_mmu_idx(CPUArchState *env, uint32_t cd,
     target_ulong pesbt;
     target_ulong cursor;
     bool tag = load_cap_from_memory_raw_tag_mmu_idx(
-        env, &pesbt, &cursor, cb, cbp, addr, _host_return_address, NULL, NULL,
-        mmu_idx);
+        env, &pesbt, &cursor, cb, cbp, addr, _host_return_address, NULL, true,
+        NULL, mmu_idx);
     update_compressed_capreg(env, cd, pesbt, tag, cursor);
 }
 
@@ -68,7 +68,8 @@ void helper_store_cap_via_cap_mmu_idx(CPUArchState *env, uint32_t cd,
                          CHERI_CAP_SIZE, _host_return_address, cbp,
                          CHERI_CAP_SIZE, raise_unaligned_store_exception);
 
-    store_cap_to_memory_mmu_index(env, cd, addr, _host_return_address, mmu_idx);
+    store_cap_to_memory_mmu_index(env, cd, addr, _host_return_address, mmu_idx,
+                                  true);
 }
 
 void helper_load_cap_pair_via_cap(CPUArchState *env, uint32_t cd, uint32_t cd2,
@@ -87,10 +88,10 @@ void helper_load_cap_pair_via_cap(CPUArchState *env, uint32_t cd, uint32_t cd2,
     uint64_t pesbt;
     uint64_t cursor;
     bool tag = load_cap_from_memory_raw(env, &pesbt, &cursor, cb, cbp, addr,
-                                        _host_return_address, NULL);
+                                        _host_return_address, NULL, true);
 
     load_cap_from_memory(env, cd2, cb, cbp, addr + CHERI_CAP_SIZE,
-                         _host_return_address, NULL);
+                         _host_return_address, NULL, true);
     // Once the second load has finished, we can modify the register file.
     update_compressed_capreg(env, cd, pesbt, tag, cursor);
 }
@@ -105,12 +106,13 @@ void helper_store_cap_pair_via_cap(CPUArchState *env, uint32_t cd, uint32_t cd2,
     cap_check_common_reg(perms_for_store(env, cd), env, cb, addr,
                          CHERI_CAP_SIZE, _host_return_address, cbp,
                          CHERI_CAP_SIZE, raise_unaligned_store_exception);
-    store_cap_to_memory(env, cd, addr, _host_return_address);
+    store_cap_to_memory(env, cd, addr, _host_return_address, true);
     cap_check_common_reg(perms_for_store(env, cd2), env, cb,
                          addr + CHERI_CAP_SIZE, CHERI_CAP_SIZE,
                          _host_return_address, cbp, CHERI_CAP_SIZE,
                          raise_unaligned_store_exception);
-    store_cap_to_memory(env, cd2, addr + CHERI_CAP_SIZE, _host_return_address);
+    store_cap_to_memory(env, cd2, addr + CHERI_CAP_SIZE, _host_return_address,
+                        true);
 }
 
 void helper_load_exclusive_cap_via_cap(CPUArchState *env, uint32_t cd,
@@ -133,13 +135,13 @@ void helper_load_exclusive_cap_via_cap(CPUArchState *env, uint32_t cd,
     bool raw_tag;
     bool tag1 = load_cap_from_memory_raw_tag(
         env, &env->exclusive_high, &env->exclusive_val, cb, cbp, addr,
-        _host_return_address, NULL, &raw_tag);
+        _host_return_address, NULL, true, &raw_tag);
     env->exclusive_tag = raw_tag;
 
     if (cd2 != REG_NONE) {
         bool tag2 = load_cap_from_memory_raw_tag(
             env, &env->exclusive_high2, &env->exclusive_val2, cb, cbp,
-            addr + CHERI_CAP_SIZE, _host_return_address, NULL, &raw_tag);
+            addr + CHERI_CAP_SIZE, _host_return_address, NULL, true, &raw_tag);
         env->exclusive_tag2 = raw_tag;
         update_compressed_capreg(env, cd2, env->exclusive_high2, tag2,
                                  env->exclusive_val2);
@@ -187,10 +189,29 @@ void helper_store_exclusive_cap_via_cap(CPUArchState *env, uint32_t rs,
     temp_perms &= ~CAP_PERM_LOAD_CAP;
     CAP_cc(update_perms)(&cbp, temp_perms);
 
+    tag_writer_lock_t low_lock = NULL;
+    tag_writer_lock_t high_lock = NULL;
+
     // Check first cap value equal
     if (success) {
+
+        /* Get both locks
+         * (for the strongest possible operation that might occur)
+         */
+        int mmu_indx = cpu_mmu_index(env, false);
+
+        cheri_lock_for_tag_set(env, addr, cb, NULL, _host_return_address,
+                               mmu_indx, &low_lock);
+        cheri_tag_writer_push_free_on_exception(env, low_lock);
+
+        if (cd2 != REG_NONE) {
+            cheri_lock_for_tag_set(env, addr + CHERI_CAP_SIZE, cb, NULL,
+                                   _host_return_address, mmu_indx, &high_lock);
+            cheri_tag_writer_push_free_on_exception(env, high_lock);
+        }
+
         load_cap_from_memory_raw_tag(env, &pesbt, &cursor, cb, &cbp, addr,
-                                     _host_return_address, NULL, &tag);
+                                     _host_return_address, NULL, false, &tag);
 
         if ((cursor != env->exclusive_val) || (pesbt != env->exclusive_high) ||
             (tag != env->exclusive_tag))
@@ -201,17 +222,27 @@ void helper_store_exclusive_cap_via_cap(CPUArchState *env, uint32_t rs,
     if (success && cd2 != REG_NONE) {
         load_cap_from_memory_raw_tag(env, &pesbt, &cursor, cb, &cbp,
                                      addr + CHERI_CAP_SIZE,
-                                     _host_return_address, NULL, &tag);
+                                     _host_return_address, NULL, false, &tag);
         if ((cursor != env->exclusive_val2) ||
             (pesbt != env->exclusive_high2) || (tag != env->exclusive_tag2))
             success = false;
     }
 
     if (success) {
-        store_cap_to_memory(env, cd, addr, _host_return_address);
+        store_cap_to_memory(env, cd, addr, _host_return_address, false);
         if (cd2 != REG_NONE)
             store_cap_to_memory(env, cd2, addr + CHERI_CAP_SIZE,
-                                _host_return_address);
+                                _host_return_address, false);
+    }
+
+    if (high_lock) {
+        cheri_tag_reader_pop_free_on_exception(env);
+        cheri_tag_writer_release(high_lock);
+    }
+
+    if (low_lock) {
+        cheri_tag_reader_pop_free_on_exception(env);
+        cheri_tag_writer_release(low_lock);
     }
 
     env->exclusive_addr = -1;
@@ -243,12 +274,18 @@ static void swap_cap_via_cap_impl(CPUArchState *env, uint32_t cd, uint32_t cs,
         probe_cap_write(env, addr, CHERI_CAP_SIZE, mmu_index,
                         _host_return_address);
 
+    tag_writer_lock_t lock = NULL;
+
+    cheri_lock_for_tag_set(env, addr, cb, NULL, _host_return_address,
+                           cpu_mmu_index(env, false), &lock);
+    cheri_tag_writer_push_free_on_exception(env, lock);
+
     // load (without modifying cs as we will need it for the comparison)
 
     uint64_t pesbt;
     uint64_t cursor;
     bool tag = load_cap_from_memory_raw(env, &pesbt, &cursor, cb, cbp, addr,
-                                        _host_return_address, NULL);
+                                        _host_return_address, NULL, false);
 
     bool do_store;
 
@@ -262,7 +299,7 @@ static void swap_cap_via_cap_impl(CPUArchState *env, uint32_t cd, uint32_t cs,
 
     // Store
     if (do_store) {
-        store_cap_to_memory(env, cd, addr, _host_return_address);
+        store_cap_to_memory(env, cd, addr, _host_return_address, false);
     } else {
         cd_tagged = get_without_decompress_tag(env, cd);
         // Even if there is no store, we possibly need an MMU permission fault
@@ -270,6 +307,9 @@ static void swap_cap_via_cap_impl(CPUArchState *env, uint32_t cd, uint32_t cs,
             probe_write(env, addr, CHERI_CAP_SIZE, mmu_index,
                         _host_return_address);
     }
+
+    cheri_tag_reader_pop_free_on_exception(env);
+    cheri_tag_writer_release(lock);
 
     // Write back to cs
     update_compressed_capreg(env, cs, pesbt, tag, cursor);
@@ -316,9 +356,11 @@ void helper_load_pair_and_branch_and_link(CPUArchState *env, uint32_t cn,
                          raise_unaligned_load_exception);
 
     cap_register_t target = load_and_decompress_cap_from_memory_raw(
-        env, cn, &base, addr + CHERI_CAP_SIZE, _host_return_address, NULL);
+        env, cn, &base, addr + CHERI_CAP_SIZE, _host_return_address, NULL,
+        true);
     // We do this load SECOND as it has a register-file side effect.
-    load_cap_from_memory(env, ct, cn, &base, addr, _host_return_address, NULL);
+    load_cap_from_memory(env, ct, cn, &base, addr, _host_return_address, NULL,
+                         true);
 
     cheri_jump_and_link(env, &target, cap_get_cursor(&target), link, link_pc,
                         flags);
@@ -346,7 +388,7 @@ void helper_load_and_branch_and_link(CPUArchState *env, uint32_t cn,
                          raise_unaligned_load_exception);
 
     cap_register_t target = load_and_decompress_cap_from_memory_raw(
-        env, cn, &base, addr, _host_return_address, NULL);
+        env, cn, &base, addr, _host_return_address, NULL, true);
     cheri_jump_and_link(env, &target, cap_get_cursor(&target), link, link_pc,
                         flags);
 }

--- a/target/cheri-common/cheri-helper-utils.h
+++ b/target/cheri-common/cheri-helper-utils.h
@@ -231,14 +231,13 @@ static inline const char* cheri_cause_str(CheriCapExcCause cause) {
 }
 
 void store_cap_to_memory(CPUArchState *env, uint32_t cs, target_ulong vaddr,
-                         target_ulong retpc);
+                         target_ulong retpc, bool take_lock);
 void store_cap_to_memory_mmu_index(CPUArchState *env, uint32_t cs,
                                    target_ulong vaddr, target_ulong retpc,
-                                   int mmu_idx);
-
+                                   int mmu_idx, bool take_lock);
 void load_cap_from_memory(CPUArchState *env, uint32_t cd, uint32_t cb,
                           const cap_register_t *source, target_ulong vaddr,
-                          target_ulong retpc, hwaddr *physaddr);
+                          target_ulong retpc, hwaddr *physaddr, bool take_lock);
 
 static inline bool cap_is_local(CPUArchState *env, uint32_t cs)
 {
@@ -359,20 +358,22 @@ cap_check_common_reg(uint32_t required_perms, CPUArchState *env, uint32_t cb,
 bool load_cap_from_memory_raw(CPUArchState *env, target_ulong *pesbt,
                               target_ulong *cursor, uint32_t cb,
                               const cap_register_t *source, target_ulong vaddr,
-                              target_ulong retpc, hwaddr *physaddr);
+                              target_ulong retpc, hwaddr *physaddr,
+                              bool take_lock);
 bool load_cap_from_memory_raw_tag(CPUArchState *env, target_ulong *pesbt,
                                   target_ulong *cursor, uint32_t cb,
                                   const cap_register_t *source,
                                   target_ulong vaddr, target_ulong retpc,
-                                  hwaddr *physaddr, bool *raw_tag);
+                                  hwaddr *physaddr, bool take_lock,
+                                  bool *raw_tag);
 bool load_cap_from_memory_raw_tag_mmu_idx(
     CPUArchState *env, target_ulong *pesbt, target_ulong *cursor, uint32_t cb,
     const cap_register_t *source, target_ulong vaddr, target_ulong retpc,
-    hwaddr *physaddr, bool *raw_tag, int mmu_idx);
+    hwaddr *physaddr, bool take_lock, bool *raw_tag, int mmu_idx);
 /* Useful for the load+branch capability helpers. */
 cap_register_t load_and_decompress_cap_from_memory_raw(
     CPUArchState *env, uint32_t cb, const cap_register_t *source,
-    target_ulong vaddr, target_ulong retpc, hwaddr *physaddr);
+    target_ulong vaddr, target_ulong retpc, hwaddr *physaddr, bool take_lock);
 
 void cheri_jump_and_link(CPUArchState *env, const cap_register_t *target,
                          target_ulong addr, uint32_t link_reg,

--- a/target/cheri-common/cheri_tagmem.c
+++ b/target/cheri-common/cheri_tagmem.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2015-2016 Stacey Son <sson@FreeBSD.org>
  * Copyright (c) 2016-2018 Alfredo Mazzinghi <am2419@cl.cam.ac.uk>
  * Copyright (c) 2016-2018 Alex Richardson <Alexander.Richardson@cl.cam.ac.uk>
+ * Copyright (c) 2021-2021 Lawrence Esswood <le277@cam.ac.uk>
  * All rights reserved.
  *
  * This software was developed by SRI International and the University of
@@ -50,8 +51,6 @@
 #error "Should only be included for TARGET_CHERI"
 #endif
 
-// XXX: use secure/target_tlb_bit0/target_tlb_bit1 for cheri TLB permissions?
-
 /*
  * Tagged Memory Emulation
  *
@@ -65,21 +64,17 @@
  * This 4K number is arbitary and depending on the workload other sizes may be
  * better.
  *
- * Note: We also support an mode where we use one byte per tag. This makes it
- * easy to set or unset a tag without the need of locking or atomics.
- * This requires eight times the memory.
+ * If MTTCG is not enabled, one bit is used per tag in a dense bitmap.
  *
- * As tag accesses are not atomic with regard to data writes/reads spurious
- * invalid capabilities could be created in a threaded context.
- * Therefore, we don't use atomic bitwise RMW operations and the one byte per
- * tag variant actually performs slightly worse due to increased memory usage.
- *
- * FIXME: find a solution to make tags safe (or just always disable multi-tcg)
+ * If MTTCG is enabled, each tag bit is combined with a lock making the size
+ * up to a byte per tag. See cheri_tagmem.h for how the interface should be
+ * used.
  *
  * XXX Should consider adding a reference count per tag block so that
  * blocks can be deallocated when no longer used maybe.
  *
- * FIXME: rewrite using somethign more like the upcoming MTE changes (https://github.com/rth7680/qemu/commits/tgt-arm-mte-user)
+ * FIXME: rewrite using somethign more like the upcoming MTE changes
+ * (https://github.com/rth7680/qemu/commits/tgt-arm-mte-user)
  *
  * XXX: I/O threads still exist even without MTTCG and need to have tag
  * clearing be atomic with their writes. Currently various places just write to
@@ -89,6 +84,23 @@
  * patterns on top of valid capabilities and try to race to read in between the
  * DMA write and the tag invalidate.
  */
+
+/* Define to do some extra checks around spinlocks */
+//#define DEBUG_SPIN_LOCKS
+
+/*
+ * Report if spin locks are being held too long (only if DEBUG_SPIN_LOCKS).
+ * I see O(10 000) pretty regularly, at least every second or so.
+ * I more rarely see O(10 000 000), however, printing the debug messages is done
+ * with the lock held, so may be significantly increasing the time they are held
+ * for.
+ * TODO: If these are being held too long, maybe we should be sleeping? Should
+ * only ever happen if the core holding the lock is de-scheduled.
+ */
+
+#define INSTRUMENT_SPIN_REPORT 10000
+/* Assert if held a very long time */
+#define SPIN_TOO_MANY 10000000000ULL
 
 #define CAP_TAGBLK_SHFT     12          // 2^12 or 4096 tags per block
 #define CAP_TAGBLK_MSK      ((1 << CAP_TAGBLK_SHFT) - 1)
@@ -102,12 +114,36 @@
 
 _Static_assert(CAP_TAG_GET_MANY_SHFT <= 3, "");
 
+/* Pack/unpack to make get/set multiple tags atomic
+ * (assuming the host atomic size is large enough)
+ * lock_tags are indexed as bytes, and so are always little endian.
+ * Bitmaps are indexed as longs, and so are host endian.
+ */
+
 #if (CAP_TAG_GET_MANY_SHFT == 3)
-#define byte_unpack byte_unpack_64
-#define byte_pack byte_pack_64
+#define byte_unpack_he byte_unpack_64
+#define byte_pack_he   byte_pack_64
+#ifdef HOST_WORDS_BIGENDIAN
+#define byte_unpack_le byte_unpack_swap_64
+#define byte_pack_le   byte_pack_swap_64
 #else
-#define byte_unpack byte_unpack_32
-#define byte_pack byte_pack_32
+#define byte_unpack_le byte_unpack_64
+#define byte_pack_le   byte_pack_64
+#endif
+#define packed_t uint64_t
+#elif (CAP_TAG_GET_MANY_SHFT == 2)
+#define byte_unpack_he byte_unpack_32
+#define byte_pack_he   byte_pack_32
+#ifdef HOST_WORDS_BIGENDIAN
+#define byte_unpack_le byte_unpack_swap_32
+#define byte_pack_le   byte_pack_swap_32
+#else
+#define byte_unpack_le byte_unpack_32
+#define byte_pack_le   byte_pack_32
+#endif
+#define packed_t uint32_t
+#else
+#error "No packed type defined for this CAP_TAG_GET_MANY_SHFT"
 #endif
 
 #define CAP_TAG_GET_MANY_MASK ((1 << (1UL << CAP_TAG_GET_MANY_SHFT)) - 1UL)
@@ -121,8 +157,193 @@ static inline size_t num_tagblocks(RAMBlock* ram)
     return result;
 }
 
+/* A CHERI tag with a readers-writer lock.
+ * Write preferring as if one core is spinning waiting for a tag to be updated,
+ * the write needs to make it through for progress to be made.
+ * This lock should never be held for more than the duration of an instruction.
+ */
+
+typedef struct lock_tag {
+    uint8_t as_int;
+} lock_tag;
+
+#define LOCKTAG_MASK_TAG           (1 << 0)
+#define LOCKTAG_MASK_WRITE_LOCKED  (1 << 1)
+#define LOCKTAG_MASK_WRITE_WAITING (1 << 2)
+#define LOCKTAG_MASK_READERS       (0b11111 << 3)
+#define LOCKTAG_MASK_READER_INC    (1 << 3)
+
+#ifdef DEBUG_SPIN_LOCKS
+
+uint64_t read_spins_max = 0;
+uint64_t write_spins_max = 0;
+
+#define assert_write_locked(lock)                                              \
+    assert(lock->as_int &LOCKTAG_MASK_WRITE_LOCKED)
+#define assert_read_locked(lock) assert(lock->as_int &LOCKTAG_MASK_READERS)
+
+static void spins_report(const char *info, uint64_t new, uint64_t *max_ptr)
+{
+    uint64_t max = *max_ptr;
+    if (new > max) {
+        qatomic_cmpxchg(max_ptr, max, new);
+        printf("New maximum spins for %s: %ld\n", info, new);
+    }
+    if (new > INSTRUMENT_SPIN_REPORT) {
+        printf("Large number of spins for %s: %ld\n", info, new);
+    }
+}
+
+#define spins_assert(spins)                                                    \
+    assert(spins < SPIN_TOO_MANY && "lock held too long");
+
+#else
+
+#define spins_report(...)
+#define spins_assert(...)
+#define assert_write_locked(...)
+#define assert_read_locked(...)
+
+#endif
+
+/* Acquire / release. All acquires (read and write) return the tag.
+ * read acquire and read release can optionally set the tag.
+ */
+
+static bool lock_tag_read_tag_and_acquire_lock(lock_tag *lock)
+{
+    lock_tag old = *lock;
+
+    int64_t spins = 0;
+    do {
+        if (!(old.as_int &
+              (LOCKTAG_MASK_WRITE_WAITING | LOCKTAG_MASK_WRITE_LOCKED))) {
+            lock_tag new = old;
+            /* (TODO: a static assert that we don't have more than 31 host
+             * threads). Overflow precluded by number of threads. */
+            new.as_int += LOCKTAG_MASK_READER_INC;
+            lock_tag got = { .as_int = qatomic_cmpxchg(
+                                 &lock->as_int, old.as_int, new.as_int) };
+            if (got.as_int == old.as_int)
+                break;
+            old = got;
+        } else {
+            old = *lock;
+        }
+        spins++;
+        spins_assert(spins);
+    } while (true);
+    spins_report("read acquire", spins, &read_spins_max);
+    return old.as_int & LOCKTAG_MASK_TAG;
+}
+
+static bool lock_tag_release_read(lock_tag *lock)
+{
+    assert_read_locked(lock);
+    lock_tag tag = { .as_int = qatomic_fetch_sub(&lock->as_int,
+                                                 LOCKTAG_MASK_READER_INC) };
+    return tag.as_int & LOCKTAG_MASK_TAG;
+}
+
+/* Generic implementation for anything that might want to take the lock as
+ * a writer.
+ * @set_tag: will also set the tag when taking the lock
+ * @tag: what to set the tag to (if set_tag)
+ * @with_release: will also release the lock afterwards
+ */
+static bool lock_tag_write_tag_and_acquire_lock_impl(lock_tag *lock,
+                                                     bool set_tag, bool tag,
+                                                     bool with_release)
+{
+    lock_tag old = *lock;
+    uint64_t spins = 0;
+    do {
+        uint8_t read_and_wait =
+            LOCKTAG_MASK_READERS | LOCKTAG_MASK_WRITE_WAITING;
+        if ((old.as_int & LOCKTAG_MASK_WRITE_LOCKED) ||
+            ((old.as_int & read_and_wait) == read_and_wait)) {
+            old = *lock;
+        } else {
+            lock_tag new = old;
+            if (old.as_int & LOCKTAG_MASK_READERS) {
+                new.as_int |= LOCKTAG_MASK_WRITE_WAITING;
+            } else {
+                if (!with_release)
+                    new.as_int |= LOCKTAG_MASK_WRITE_LOCKED;
+                if (set_tag)
+                    new.as_int = (new.as_int & ~LOCKTAG_MASK_TAG) | tag;
+            }
+            lock_tag got = { .as_int = qatomic_cmpxchg(
+                                 &lock->as_int, old.as_int, new.as_int) };
+            if ((got.as_int == old.as_int) &&
+                !(old.as_int & LOCKTAG_MASK_READERS))
+                break;
+
+            old = got;
+        }
+        spins++;
+        spins_assert(spins);
+    } while (true);
+    spins_report("write acquire", spins, &read_spins_max);
+    assert_write_locked(lock);
+    return old.as_int & LOCKTAG_MASK_TAG;
+}
+
+static bool lock_tag_write_tag_and_acquire_lock(lock_tag *lock, bool tag)
+{
+    return lock_tag_write_tag_and_acquire_lock_impl(lock, true, tag, false);
+}
+
+static bool lock_tag_write_acquire_lock(lock_tag *lock)
+{
+    return lock_tag_write_tag_and_acquire_lock_impl(lock, false, false, false);
+}
+
+static void lock_tag_release_write(lock_tag *lock)
+{
+    assert_write_locked(lock);
+    qatomic_fetch_and(&lock->as_int, LOCKTAG_MASK_TAG);
+}
+
+static void lock_tag_write_tag_and_release(lock_tag *lock, bool tag)
+{
+    assert_write_locked(lock);
+    qatomic_set(&lock->as_int, tag ? LOCKTAG_MASK_TAG : 0);
+}
+
+/* These two don't take locks outs, so use with caution */
+/* I think, as long as every other access respects locks, we don't need
+ * atomics here */
+static bool lock_tag_read(lock_tag *lock)
+{
+#ifdef CONFIG_DEBUG_TCG
+    assert(!parallel_cpus ||
+           (lock->as_int & (LOCKTAG_MASK_READERS | LOCKTAG_MASK_WRITE_LOCKED)));
+#endif
+    return lock->as_int & LOCKTAG_MASK_TAG;
+}
+
+static bool lock_tag_write(lock_tag *lock, bool tag, bool check_locked)
+{
+#ifdef CONFIG_DEBUG_TCG
+    if (check_locked)
+        assert(!parallel_cpus || (lock->as_int & LOCKTAG_MASK_WRITE_LOCKED));
+#endif
+    bool old = lock->as_int & LOCKTAG_MASK_TAG;
+    lock->as_int = (lock->as_int & ~LOCKTAG_MASK_TAG) | tag;
+    return old;
+}
+
 typedef struct CheriTagBlock {
-    DECLARE_BITMAP(tag_bitmap, CAP_TAGBLK_SIZE);
+    /* It would be silly to use locks for non-mttcg. So support both formats and
+     * use one or the other depending on qemu_tcg_mttcg_enabled()
+     * It looks like single stepping can be turned on/off, no probably best
+     * not to use parallel_cpus.
+     */
+    union {
+        DECLARE_BITMAP(tag_bitmap, CAP_TAGBLK_SIZE);
+        lock_tag locked_tags[CAP_TAGBLK_SIZE];
+    };
 } CheriTagBlock;
 
 
@@ -130,7 +351,11 @@ static CheriTagBlock *cheri_tag_new_tagblk(RAMBlock *ram, uint64_t tagidx)
 {
     CheriTagBlock *tagblk, *old;
 
-    tagblk = g_malloc0(sizeof(CheriTagBlock));
+    size_t size = tagmem_use_locking()
+                      ? sizeof(((CheriTagBlock *)0)->locked_tags)
+                      : sizeof(((CheriTagBlock *)0)->tag_bitmap);
+
+    tagblk = g_malloc0(size);
     if (tagblk == NULL) {
         error_report("Can't allocate tag block.");
         exit(1);
@@ -161,74 +386,207 @@ static inline QEMU_ALWAYS_INLINE CheriTagBlock *cheri_tag_block(size_t tag_index
     return tagmem[tagbock_index];
 }
 
-static inline QEMU_ALWAYS_INLINE bool tagblock_get_tag_tagmem(void *tagmem,
-                                                              size_t index)
+static inline QEMU_ALWAYS_INLINE bool tagmem_get_tag(void *tagmem, size_t index,
+                                                     tag_reader_lock_t *lock)
 {
-    unsigned long *p = (unsigned long *)tagmem + BIT_WORD(index);
-    unsigned long word;
+    if (tagmem_use_locking()) {
+        lock_tag *locktag = (lock_tag *)tagmem + index;
+        if (lock) {
+            *lock = (tag_reader_lock_t)locktag;
+            return lock_tag_read_tag_and_acquire_lock(locktag);
+        } else {
+            return lock_tag_read(locktag);
+        }
+    } else {
+        if (lock)
+            *lock = TAG_LOCK_NONE;
+        unsigned long *p = (unsigned long *)tagmem + BIT_WORD(index);
+        unsigned long word;
 
-    word = qatomic_read(p);
-    return (word & BIT_MASK(index)) != 0;
+        word = qatomic_read(p);
+        return (word & BIT_MASK(index)) != 0;
+    }
 }
 
 static inline QEMU_ALWAYS_INLINE bool tagblock_get_tag(CheriTagBlock *block,
                                                        size_t block_index)
 {
-    return block ? tagblock_get_tag_tagmem(block->tag_bitmap, block_index)
-                 : false;
+    return block ? test_bit(block_index, block->tag_bitmap) : false;
 }
 
-static inline QEMU_ALWAYS_INLINE int
-tagblock_get_tag_many_tagmem(void *tagmem, size_t block_index)
+static inline QEMU_ALWAYS_INLINE bool
+tagblock_get_locktag(CheriTagBlock *block, size_t block_index,
+                     tag_reader_lock_t *lock)
 {
-    unsigned long *p = (unsigned long *)tagmem + BIT_WORD(block_index);
-    unsigned long word;
+    if (!block) {
+        if (lock)
+            *lock = TAG_LOCK_NONE;
+        return false;
+    }
 
-    word = qatomic_read(p);
-    return (word >> (block_index % BITS_PER_LONG)) & CAP_TAG_GET_MANY_MASK;
-}
-
-static inline QEMU_ALWAYS_INLINE void
-tagblock_set_tag_tagmem(void *tagmem, size_t block_index)
-{
-    unsigned long *p = (unsigned long *)tagmem + BIT_WORD(block_index);
-
-    qatomic_or(p, BIT_MASK(block_index));
-}
-
-static inline QEMU_ALWAYS_INLINE void
-tagblock_set_tag_many_tagmem(void *tagmem, size_t block_index, uint8_t tags)
-{
-    unsigned long *p = (unsigned long *)tagmem + BIT_WORD(block_index);
-    size_t shift = block_index % BITS_PER_LONG;
-    unsigned long mask = CAP_TAG_GET_MANY_MASK << shift;
-    unsigned long tags_shifted = ((unsigned long)tags << shift) & mask;
-
-    if (likely(tags_shifted == 0)) {
-        qatomic_and(p, ~mask);
+    lock_tag *locktag = &block->locked_tags[block_index];
+    if (lock) {
+        *lock = (tag_reader_lock_t)locktag;
+        return lock_tag_read_tag_and_acquire_lock(locktag);
     } else {
-        unsigned long old, new, cmp;
-        cmp = qatomic_read(p);
-        do {
-            old = cmp;
-            new = (old & ~mask) | tags_shifted;
-            cmp = qatomic_cmpxchg(p, old, new);
-        } while (cmp != old);
+        return lock_tag_read(locktag);
     }
 }
 
-static inline QEMU_ALWAYS_INLINE void tagblock_clear_tag_tagmem(void *tagmem,
-                                                                size_t index)
+static inline QEMU_ALWAYS_INLINE int
+tagmem_get_tag_many(void *tagmem, size_t block_index, bool take_lock)
 {
-    unsigned long *p = (unsigned long *)tagmem + BIT_WORD(index);
+    if (tagmem_use_locking()) {
+        lock_tag *lock = ((lock_tag *)tagmem) + block_index;
+        if (!take_lock) {
+            /* If we don't need the lock we can just read a bunch of
+             * these at once */
+            packed_t raw = qatomic_read((packed_t *)lock);
+            return byte_pack_le(raw);
+        } else {
+            /* Otherwise acquire the locks in order */
+            lock_tag *start = lock;
+            int result = 0;
+            for (int ndx = 0; ndx != (1 << CAP_TAG_GET_MANY_SHFT); ndx++) {
+                result |= lock_tag_read_tag_and_acquire_lock(start + ndx)
+                              ? (1 << ndx)
+                              : 0;
+            }
+            return result;
+        }
+    } else {
+        unsigned long *p = (unsigned long *)tagmem + BIT_WORD(block_index);
+        unsigned long word;
 
-    qatomic_and(p, ~BIT_MASK(index));
+        word = qatomic_read(p);
+        return (word >> (block_index % BITS_PER_LONG)) & CAP_TAG_GET_MANY_MASK;
+    }
+}
+
+static inline QEMU_ALWAYS_INLINE void tagmem_set_tag(void *tagmem,
+                                                     size_t block_index,
+                                                     tag_writer_lock_t *lock,
+                                                     bool lock_only)
+{
+    if (tagmem_use_locking()) {
+        lock_tag *lockTag = (lock_tag *)tagmem + block_index;
+        if (lock) {
+            *lock = (tag_writer_lock_t)(lockTag);
+            lock_tag_write_tag_and_acquire_lock_impl(lockTag, !lock_only, 1,
+                                                     false);
+        } else {
+            lock_tag_write(lockTag, 1, true);
+        }
+    } else {
+        if (lock)
+            *lock = TAG_LOCK_NONE;
+
+        unsigned long *p = (unsigned long *)tagmem + BIT_WORD(block_index);
+
+        qatomic_or(p, BIT_MASK(block_index));
+    }
+}
+
+/* A 1 in the lowest bit in each byte of a packed_t */
+#define GET_SET_MANY_LOCKTAG_TAG_MASK (((packed_t)~0ULL) / 0xFF)
+
+static inline QEMU_ALWAYS_INLINE void tagmem_set_tag_many(void *tagmem,
+                                                          size_t block_index,
+                                                          uint8_t tags,
+                                                          bool take_lock)
+{
+    if (tagmem_use_locking()) {
+        lock_tag *lock = ((lock_tag *)tagmem) + block_index;
+
+        /* TODO: Needs testing on Morello multicore.
+         *  If something breaks around the STCT instruction it is THIS. */
+
+        if (!take_lock) {
+            /* Although we are not taking any locks, we still need to not
+             * touch any of the lock bits as other operations may be using them.
+             */
+            if (tags == 0) {
+                /* If setting to zeros this is just an and. */
+                qatomic_and((packed_t *)lock, ~GET_SET_MANY_LOCKTAG_TAG_MASK);
+            } else if (tags == CAP_TAG_GET_MANY_MASK) {
+                /* If setting to ones it is an or. */
+                qatomic_or((packed_t *)lock, GET_SET_MANY_LOCKTAG_TAG_MASK);
+            } else {
+                /* Otherwise we need a cmpxchg loop. */
+                packed_t unpacked = byte_unpack_le(tags);
+                packed_t old;
+                packed_t got = *(packed_t *)lock;
+                do {
+                    old = got;
+                    got = qatomic_cmpxchg(
+                        (packed_t *)lock, old,
+                        (old & ~GET_SET_MANY_LOCKTAG_TAG_MASK) | unpacked);
+                } while (old != got);
+            }
+        } else {
+            lock_tag *start = lock;
+            lock_tag *end = start + (1 << CAP_TAG_GET_MANY_SHFT);
+            for (; start != end; start++) {
+                lock_tag_write_tag_and_acquire_lock(start, tags & 1);
+                tags = tags >> 1;
+            }
+        }
+    } else {
+        unsigned long *p = (unsigned long *)tagmem + BIT_WORD(block_index);
+        size_t shift = block_index % BITS_PER_LONG;
+        unsigned long mask = CAP_TAG_GET_MANY_MASK << shift;
+        unsigned long tags_shifted = ((unsigned long)tags << shift) & mask;
+
+        if (likely(tags_shifted == 0)) {
+            qatomic_and(p, ~mask);
+        } else {
+            unsigned long old, new, cmp;
+            cmp = qatomic_read(p);
+            do {
+                old = cmp;
+                new = (old & ~mask) | tags_shifted;
+                cmp = qatomic_cmpxchg(p, old, new);
+            } while (cmp != old);
+        }
+    }
+}
+
+static inline QEMU_ALWAYS_INLINE void tagmem_clear_tag(void *tagmem,
+                                                       size_t index,
+                                                       tag_writer_lock_t *lock,
+                                                       bool lock_only)
+{
+    if (tagmem_use_locking()) {
+        lock_tag *lockTag = (lock_tag *)tagmem + index;
+        if (lock) {
+            *lock = (tag_writer_lock_t)lockTag;
+            lock_tag_write_tag_and_acquire_lock_impl(lockTag, !lock_only, 0,
+                                                     false);
+        } else {
+            lock_tag_write(lockTag, 0, true);
+        }
+    } else {
+        if (lock)
+            *lock = TAG_LOCK_NONE;
+        unsigned long *p = (unsigned long *)tagmem + BIT_WORD(index);
+        qatomic_and(p, ~BIT_MASK(index));
+    }
 }
 
 static inline QEMU_ALWAYS_INLINE void tagblock_clear_tag(CheriTagBlock *block,
                                                          size_t block_index)
 {
-    tagblock_clear_tag_tagmem(block->tag_bitmap, block_index);
+    unsigned long *p =
+        (unsigned long *)block->tag_bitmap + BIT_WORD(block_index);
+    qatomic_and(p, ~BIT_MASK(block_index));
+}
+
+static inline QEMU_ALWAYS_INLINE void
+tagblock_clear_locktag_with_lock_and_release(CheriTagBlock *block,
+                                             size_t block_index)
+{
+    lock_tag *lockTag = &block->locked_tags[block_index];
+    lock_tag_write_tag_and_acquire_lock_impl(lockTag, true, 0, true);
 }
 
 void cheri_tag_init(MemoryRegion *mr, uint64_t memory_size)
@@ -244,12 +602,6 @@ void cheri_tag_init(MemoryRegion *mr, uint64_t memory_size)
     if (mr->ram_block->cheri_tags == NULL) {
         error_report("%s: Can't allocated tag memory", __func__);
         exit(-1);
-    }
-    if (qemu_tcg_mttcg_enabled()) {
-        warn_report("The CHERI tagged memory implementation is not thread-safe "
-                    "and therefore not compatible with MTTCG. Capability tags "
-                    "may mysteriously appear/disappear. Run with \"--accel "
-                    "tcg,thread=single\" to fix.");
     }
 }
 
@@ -298,7 +650,11 @@ void *cheri_tagmem_for_addr(CPUArchState *env, target_ulong vaddr,
 
     if (tagblk != NULL) {
         const size_t tagblk_index = CAP_TAGBLK_IDX(tag);
-        return tagblk->tag_bitmap + BIT_WORD(tagblk_index);
+        if (tagmem_use_locking()) {
+            return tagblk->locked_tags + tagblk_index;
+        } else {
+            return tagblk->tag_bitmap + BIT_WORD(tagblk_index);
+        }
     }
 
     if (!(*prot & PAGE_SC_CLEAR)) {
@@ -358,26 +714,50 @@ static QEMU_ALWAYS_INLINE target_ulong tag_offset_to_addr(TagOffset offset)
 }
 
 static void *cheri_tag_invalidate_one(CPUArchState *env, target_ulong vaddr,
-                                      uintptr_t pc, int mmu_idx);
+                                      uintptr_t pc, int mmu_idx,
+                                      tag_writer_lock_t *lock, bool lock_only);
 
-void *cheri_tag_invalidate_aligned(CPUArchState *env, target_ulong vaddr,
-                                   uintptr_t pc, int mmu_idx)
+static void invalidate_from_locktag(lock_tag *lock)
 {
-    cheri_debug_assert(QEMU_IS_ALIGNED(vaddr, CHERI_CAP_SIZE));
-    return cheri_tag_invalidate_one(env, vaddr, pc, mmu_idx);
+    if (lock != TAG_LOCK_NONE) {
+        assert(lock != TAG_LOCK_ERROR);
+        lock_tag_write_tag_and_release(lock, 0);
+    }
 }
 
-void cheri_tag_invalidate(CPUArchState *env, target_ulong vaddr, int32_t size,
-                          uintptr_t pc, int mmu_idx)
+void *cheri_tag_invalidate_aligned_impl(CPUArchState *env, target_ulong vaddr,
+                                        uintptr_t pc, int mmu_idx,
+                                        tag_writer_lock_t *lock, bool lock_only)
+{
+    cheri_debug_assert(QEMU_IS_ALIGNED(vaddr, CHERI_CAP_SIZE));
+    if (lock && *lock) {
+        invalidate_from_locktag((lock_tag *)*lock);
+        return NULL;
+    }
+    return cheri_tag_invalidate_one(env, vaddr, pc, mmu_idx, lock, lock_only);
+}
+
+void cheri_tag_invalidate_impl(CPUArchState *env, target_ulong vaddr,
+                               int32_t size, uintptr_t pc, int mmu_idx,
+                               tag_writer_lock_t *first,
+                               tag_writer_lock_t *second, bool lock_only)
 {
     cheri_debug_assert(size > 0);
+
+    if (first && *first) {
+        invalidate_from_locktag((lock_tag *)*first);
+        if (second && *second)
+            invalidate_from_locktag((lock_tag *)*second);
+        return;
+    }
+
     target_ulong first_addr = vaddr;
     target_ulong last_addr = (vaddr + size - 1);
     TagOffset tag_start = addr_to_tag_offset(first_addr);
     TagOffset tag_end = addr_to_tag_offset(last_addr);
     if (likely(tag_start.value == tag_end.value)) {
         // Common case, only one tag (i.e. an aligned store)
-        cheri_tag_invalidate_one(env, vaddr, pc, mmu_idx);
+        cheri_tag_invalidate_one(env, vaddr, pc, mmu_idx, first, lock_only);
         return;
     }
     // Unaligned store -> can cross a capabiblity alignment boundary and
@@ -413,24 +793,46 @@ void cheri_tag_invalidate(CPUArchState *env, target_ulong vaddr, int32_t size,
 #endif
     for (target_ulong addr = tag_offset_to_addr(tag_start);
          addr <= tag_offset_to_addr(tag_end); addr += CHERI_CAP_SIZE) {
-        cheri_tag_invalidate_one(env, addr, pc, mmu_idx);
+        cheri_tag_invalidate_one(env, addr, pc, mmu_idx, first, lock_only);
+        first = second;
     }
 }
 
 static void *cheri_tag_invalidate_one(CPUArchState *env, target_ulong vaddr,
-                                      uintptr_t pc, int mmu_idx)
+                                      uintptr_t pc, int mmu_idx,
+                                      tag_writer_lock_t *lock, bool lock_only)
 {
+
+    if (lock)
+        *lock = TAG_LOCK_NONE;
+
     /*
      * When resolving this address in the TLB, treat it like a data store
      * (MMU_DATA_STORE) rather than a capability store (MMU_DATA_CAP_STORE),
      * so that we don't require that the SC inhibit be clear.
      */
 
-    void *host_addr = probe_write(env, vaddr, 1, mmu_idx, pc);
+    /*
+     * We use the flags version to suppress exceptions if we only want the
+     * lock. This is required as the data access might throw an exception with a
+     * higher priority. It should be the case that the data access will throw an
+     * MMU exception as well, but if it doesn't, I am returning another special
+     * lock value which can be tested later
+     * */
+    void *host_addr;
+    int access_flags = probe_access_flags(env, vaddr, MMU_DATA_STORE, mmu_idx,
+                                          lock_only, &host_addr, pc);
+
+    if (access_flags & TLB_INVALID_MASK) {
+        if (lock)
+            *lock = TAG_LOCK_ERROR;
+        return host_addr;
+    }
+
     // Only RAM and ROM regions are backed by host addresses so if
     // probe_write() returns NULL we know that we can't write the tagmem.
     if (unlikely(!host_addr)) {
-        return NULL;
+        return host_addr;
     }
 
     uintptr_t tagmem_flags;
@@ -453,14 +855,14 @@ static void *cheri_tag_invalidate_one(CPUArchState *env, target_ulong vaddr,
     // page offset.
     target_ulong tag_offset = page_vaddr_to_tag_offset(vaddr);
     if (qemu_log_instr_enabled(env)) {
-        bool old_value = tagblock_get_tag_tagmem(tagmem, tag_offset);
+        bool old_value = tagmem_get_tag(tagmem, tag_offset, NULL);
         qemu_log_instr_extra(
             env,
             "    Cap Tag Write [" TARGET_FMT_lx "/" RAM_ADDR_FMT "] %d -> 0\n",
             vaddr, qemu_ram_addr_from_host(host_addr), old_value);
     }
 
-    tagblock_clear_tag_tagmem(tagmem, tag_offset);
+    tagmem_clear_tag(tagmem, tag_offset, lock, lock_only);
     return host_addr;
 }
 
@@ -483,19 +885,34 @@ void cheri_tag_phys_invalidate(CPUArchState *env, RAMBlock *ram,
         CheriTagBlock *tagblk = cheri_tag_block(tag, ram);
         if (tagblk != NULL) {
             const size_t tagblk_index = CAP_TAGBLK_IDX(tag);
-            if (unlikely(env && vaddr && qemu_log_instr_enabled(env))) {
-                target_ulong write_vaddr =
-                    QEMU_ALIGN_DOWN(*vaddr, CHERI_CAP_SIZE) + (addr - startaddr);
-                qemu_log_instr_extra(env, "    Cap Tag Write [" TARGET_FMT_lx
-                    "/" RAM_ADDR_FMT "] %d -> 0\n", write_vaddr, addr,
-                    tagblock_get_tag(tagblk, tagblk_index));
-            } else if (unlikely(env && qemu_log_instr_enabled(env))) {
-                qemu_log_instr_extra(env, "    Cap Tag ramaddr Write ["
-                    RAM_ADDR_FMT "] %d -> 0\n", addr,
-                    tagblock_get_tag(tagblk, tagblk_index));
+            if (unlikely(env && qemu_log_instr_enabled(env))) {
+                bool old_tag =
+                    tagmem_use_locking()
+                        ? tagblock_get_locktag(tagblk, tagblk_index, NULL)
+                        : tagblock_get_tag(tagblk, tagblk_index);
+                if (vaddr) {
+                    target_ulong write_vaddr =
+                        QEMU_ALIGN_DOWN(*vaddr, CHERI_CAP_SIZE) +
+                        (addr - startaddr);
+                    qemu_log_instr_extra(env,
+                                         "    Cap Tag Write [" TARGET_FMT_lx
+                                         "/" RAM_ADDR_FMT "] %d -> 0\n",
+                                         write_vaddr, addr, old_tag);
+                } else {
+                    qemu_log_instr_extra(
+                        env,
+                        "    Cap Tag ramaddr Write [" RAM_ADDR_FMT
+                        "] %d -> 0\n",
+                        addr, old_tag);
+                }
             }
-            // changed |= tagblock_get_tag(tagblk, tagblk_index);
-            tagblock_clear_tag(tagblk, tagblk_index);
+
+            if (tagmem_use_locking()) {
+                tagblock_clear_locktag_with_lock_and_release(tagblk,
+                                                             tagblk_index);
+            } else {
+                tagblock_clear_tag(tagblk, tagblk_index);
+            }
         }
     }
 }
@@ -521,9 +938,17 @@ void cheri_tag_phys_invalidate(CPUArchState *env, RAMBlock *ram,
 #define clear_capcause_reg(env)
 #endif
 
-void *cheri_tag_set(CPUArchState *env, target_ulong vaddr, int reg,
-                    hwaddr *ret_paddr, uintptr_t pc, int mmu_idx)
+void *cheri_tag_set_impl(CPUArchState *env, target_ulong vaddr, int reg,
+                         hwaddr *ret_paddr, uintptr_t pc, int mmu_idx,
+                         tag_writer_lock_t *lock, bool lock_only)
 {
+
+    if (lock && *lock) {
+        if (*lock != TAG_LOCK_NONE)
+            lock_tag_write_tag_and_release((lock_tag *)*lock, 1);
+        return NULL;
+    }
+
     /*
      * This attempt to resolve a virtual address may cause both a data store
      * TLB fault (entry missing or D bit clear) and a capability store TLB
@@ -535,6 +960,9 @@ void *cheri_tag_set(CPUArchState *env, target_ulong vaddr, int reg,
     clear_capcause_reg(env);
 
     handle_paddr_return(write);
+
+    if (lock)
+        *lock = TAG_LOCK_NONE;
 
     if (unlikely(!host_addr)) {
         return NULL;
@@ -567,16 +995,21 @@ void *cheri_tag_set(CPUArchState *env, target_ulong vaddr, int reg,
     qemu_maybe_log_instr_extra(
         env, "    Cap Tag Write [" TARGET_FMT_lx "/" RAM_ADDR_FMT "] %d -> 1\n",
         vaddr, qemu_ram_addr_from_host(host_addr),
-        tagblock_get_tag_tagmem(tagmem, tag_offset));
+        tagmem_get_tag(tagmem, tag_offset, NULL));
 
-    tagblock_set_tag_tagmem(tagmem, tag_offset);
+    tagmem_set_tag(tagmem, tag_offset, lock, lock_only);
     return host_addr;
 }
 
 bool cheri_tag_get(CPUArchState *env, target_ulong vaddr, int reg,
                    hwaddr *ret_paddr, int *prot, uintptr_t pc, int mmu_idx,
-                   void *host_addr)
+                   void *host_addr, tag_reader_lock_t *lock)
 {
+    if (lock && *lock) {
+        return (*lock == TAG_LOCK_NONE)
+                   ? 0
+                   : lock_tag_release_read((lock_tag *)*lock);
+    }
 
     if (host_addr == NULL) {
         host_addr = probe_read(env, vaddr, 1, mmu_idx, pc);
@@ -607,7 +1040,7 @@ bool cheri_tag_get(CPUArchState *env, target_ulong vaddr, int reg,
     bool result =
         (tagmem == ALL_ZERO_TAGBLK)
             ? 0
-            : tagblock_get_tag_tagmem(tagmem, page_vaddr_to_tag_offset(vaddr));
+            : tagmem_get_tag(tagmem, page_vaddr_to_tag_offset(vaddr), lock);
 
     // XXX: Not atomic w.r.t. writes to tag memory
     qemu_maybe_log_instr_extra(
@@ -631,8 +1064,8 @@ int cheri_tag_get_many(CPUArchState *env, target_ulong vaddr, int reg,
     int result =
         ((tagmem == ALL_ZERO_TAGBLK) || (tagmem_flags & TLBENTRYCAP_FLAG_CLEAR))
             ? 0
-            : tagblock_get_tag_many_tagmem(tagmem,
-                                           page_vaddr_to_tag_offset(vaddr));
+            : tagmem_get_tag_many(tagmem, page_vaddr_to_tag_offset(vaddr),
+                                  false);
 
     if ((result && (tagmem_flags & TLBENTRYCAP_FLAG_TRAP)) ||
         (tagmem_flags & TLBENTRYCAP_FLAG_TRAP_ANY)) {
@@ -683,5 +1116,95 @@ void cheri_tag_set_many(CPUArchState *env, uint32_t tags, target_ulong vaddr,
 
     cheri_debug_assert(tagmem);
 
-    tagblock_set_tag_many_tagmem(tagmem, page_vaddr_to_tag_offset(vaddr), tags);
+    tagmem_set_tag_many(tagmem, page_vaddr_to_tag_offset(vaddr), tags, false);
+}
+
+void cheri_tag_reader_lock_impl(tag_reader_lock_t lock)
+{
+    lock_tag *lockTag = (lock_tag *)lock;
+    lock_tag_release_read(lockTag);
+}
+void cheri_tag_writer_lock_impl(tag_writer_lock_t lock)
+{
+    lock_tag *lockTag = (lock_tag *)lock;
+    lock_tag_release_write(lockTag);
+}
+
+void cheri_tag_free_lock(tag_lock_t lock)
+{
+    lock_tag *lockTag = (lock_tag *)lock;
+    if (!lock || lock == TAG_LOCK_NONE || lock == TAG_LOCK_ERROR)
+        return;
+    if (lockTag->as_int & LOCKTAG_MASK_WRITE_LOCKED)
+        lock_tag_release_write(lockTag);
+    else
+        lock_tag_release_read(lockTag);
+}
+
+/*
+ * Some TCG operations on data need to be atomic. This is done using atomic host
+ * operations, or single stepping. Tags pose a problem, as no host operations
+ * can simultaneously set tags and data, so that would leave only single
+ * stepping, which would not perform very well.
+ * Luckily, a lock now exists on every capability sized unit of memory, so
+ * atomic TCG operations are done by taking the lock and then doing a non-atomic
+ * sequence. Because it is unknown at translation time whether a location will
+ * have a tag (and therefore a lock), we cannot know whether we can rely
+ * on the tags lock or not.
+ * Therefore, we assume every location is tagged. If it is not, we asign it a
+ * dummy lock (that will always have a zero tag).
+ * We have a few of these to avoid false sharing.
+ */
+
+#define DUMMY_LOCK_BITS 16
+
+lock_tag dummy_tag_table[1 << DUMMY_LOCK_BITS];
+
+static target_ulong hash_vaddr(target_ulong vaddr)
+{
+    size_t shft = sizeof(target_ulong);
+    while (shft > DUMMY_LOCK_BITS) {
+        shft /= 2;
+        vaddr ^= vaddr >> shft;
+    }
+    return vaddr & ((1 << DUMMY_LOCK_BITS) - 1);
+}
+
+static lock_tag *get_dummy(target_ulong vaddr)
+{
+    return &dummy_tag_table[hash_vaddr(vaddr)];
+}
+
+void get_dummy_locks(target_ulong vaddr, tag_writer_lock_t *low,
+                     tag_writer_lock_t *high)
+{
+    target_ulong tag_addr1 = vaddr / CHERI_CAP_SIZE;
+    target_ulong tag_addr2 = tag_addr1 + 1;
+    tag_writer_lock_t low_dummy = NULL;
+    tag_writer_lock_t high_dummy = NULL;
+
+    if (*low == TAG_LOCK_NONE) {
+        low_dummy = get_dummy(tag_addr1);
+    }
+
+    if (*high == TAG_LOCK_NONE) {
+        high_dummy = get_dummy(tag_addr2);
+    }
+
+    if (low_dummy && high_dummy && high_dummy < low_dummy) {
+        // Keep lock order consistent.
+        tag_writer_lock_t tmp = high_dummy;
+        high_dummy = low_dummy;
+        low_dummy = tmp;
+    }
+
+    if (low_dummy) {
+        lock_tag_write_acquire_lock(low_dummy);
+        *low = low_dummy;
+    }
+
+    if (high_dummy) {
+        lock_tag_write_acquire_lock(high_dummy);
+        *high = high_dummy;
+    }
 }

--- a/target/cheri-common/cheri_tagmem.c
+++ b/target/cheri-common/cheri_tagmem.c
@@ -1133,12 +1133,12 @@ void cheri_tag_set_many(CPUArchState *env, uint32_t tags, target_ulong vaddr,
     tagmem_set_tag_many(tagmem, page_vaddr_to_tag_offset(vaddr), tags, false);
 }
 
-void cheri_tag_reader_lock_impl(tag_reader_lock_t lock)
+void cheri_tag_reader_lock_release_impl(tag_reader_lock_t lock)
 {
     lock_tag *lockTag = (lock_tag *)lock;
     lock_tag_release_read(lockTag);
 }
-void cheri_tag_writer_lock_impl(tag_writer_lock_t lock)
+void cheri_tag_writer_lock_release_impl(tag_writer_lock_t lock)
 {
     lock_tag *lockTag = (lock_tag *)lock;
     lock_tag_release_write(lockTag);

--- a/target/cheri-common/cheri_tagmem.h
+++ b/target/cheri-common/cheri_tagmem.h
@@ -56,11 +56,10 @@
  * developers want a "fast but not precise" singlecore, we could have locks off.
  *
  * If we want to throw caution to wind and really optimise the single thread
- * case, it should be noted qemu_tcg_mttcg_enabled is dynamic and so will
- * still be generating an extra branch. TARGET_SUPPORTS_MTTCG is the
- * static thing. Although qemu_tcg_mttcg_enabled will default to false if
- * TARGET_SUPPORTS_MTTCG is undefined, it can be still be overridden on the
- * command line.
+ * case, it should be noted need_concurrent_tags is dynamic and so will
+ * still be generating a few extra branchs. TARGET_SUPPORTS_MTTCG is the
+ * static thing we could use if we want to compile an extra fast but single-core
+ * only binary.
  */
 
 #define UNSAFE_SINGLE_CORE true

--- a/target/cheri-common/cheri_tagmem.h
+++ b/target/cheri-common/cheri_tagmem.h
@@ -110,8 +110,8 @@ void get_dummy_locks(target_ulong vaddr, tag_writer_lock_t *low,
 
 extern tag_writer_lock_t notag_lock_high;
 
-void cheri_tag_reader_lock_impl(tag_reader_lock_t lock);
-void cheri_tag_writer_lock_impl(tag_writer_lock_t lock);
+void cheri_tag_reader_lock_release_impl(tag_reader_lock_t lock);
+void cheri_tag_writer_lock_release_impl(tag_writer_lock_t lock);
 
 extern bool _need_concurrent_tags;
 extern bool _need_concurrent_tags_initialized;
@@ -136,13 +136,13 @@ static inline QEMU_ALWAYS_INLINE bool need_concurrent_tags(void)
 static inline void cheri_tag_reader_release(tag_reader_lock_t lock)
 {
     if (lock != TAG_LOCK_NONE && lock != NULL)
-        cheri_tag_reader_lock_impl(lock);
+        cheri_tag_reader_lock_release_impl(lock);
 }
 
 static inline void cheri_tag_writer_release(tag_writer_lock_t lock)
 {
     if (lock != TAG_LOCK_NONE && lock != NULL)
-        cheri_tag_writer_lock_impl(lock);
+        cheri_tag_writer_lock_release_impl(lock);
 }
 
 static inline cheri_exception_locks_t *

--- a/target/cheri-common/cheri_tagmem.h
+++ b/target/cheri-common/cheri_tagmem.h
@@ -31,56 +31,327 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+
+#pragma once
+
 #include "qemu/osdep.h"
 #include "cpu.h"
 #include "exec/cpu-common.h"
 #include "exec/memory.h"
+#include "cheri_tagmem_ex_locks.h"
 
 #if defined(TARGET_CHERI)
+
+/*
+ * TODO: We might want to think about the performance correctness trade-off
+ * here. On multicore, we always want to use locking.
+ * For singlecore, it would be more performant to have no locks. Not only could
+ * we cram the tags into less memory, but code paths would be simplified.
+ * However, there is still a race between normal tag access and the mass clear
+ * in cheri_tag_phys_invalidate, due to IO threads. In order to be secure,
+ * we could turn on locks. This might be valuable for people looking to test the
+ * architecture. However, this race only matters as it may create extra tags for
+ * memory written by devices. This shouldn't actually break anything. So if
+ * developers want a "fast but not precise" singlecore, we could have locks off.
+ *
+ * If we want to throw caution to wind and really optimise the single thread
+ * case, it should be noted qemu_tcg_mttcg_enabled is dynamic and so will
+ * still be generating an extra branch. TARGET_SUPPORTS_MTTCG is the
+ * static thing. Although qemu_tcg_mttcg_enabled will default to false if
+ * TARGET_SUPPORTS_MTTCG is undefined, it can be still be overridden on the
+ * command line.
+ */
+
+#define UNSAFE_SINGLE_CORE true
+
+static bool tagmem_use_locking(void)
+{
+    /* return constant true here to always be correct, but slower than needed
+     * on single core */
+    if (UNSAFE_SINGLE_CORE)
+        return qemu_tcg_mttcg_enabled();
+    else
+        return true;
+}
+
+/*
+ * Usage notes:
+ *
+ * There are few different locking patterns that might be employed, depending
+ * on whether TCG is currently multithreaded, whether reading / writing tags,
+ * whether exceptions can be thrown etc.
+ *
+ * tag get / set / invalidate have an (optional) lock argument.
+ * If it is NULL, then no locks will be taken or released
+ * (although they should be already taken elsewhere if data is also to be
+ * read/written). If provided, it can either be an input (not NULL when
+ * dereferenced) or an output. If an input, then the lock is to be released
+ * atomically with the operation. If an output, then the lock will be taken and
+ * returned to be released by the caller.
+ *
+ * The cheri_lock_for_X family will return the relevent lock for an intended
+ * operation that needs to be performed at the end of a sequence, but will not
+ * apply the operation. cheri_lock_for_tag_set can be used for invalidate,
+ * but not the other way around.
+ *
+ * Any lock taken, either with lock_for_X, or as an output from other tag
+ * operations needs to be freed by the caller. This can be done by calling
+ * cheri_tag_reader_release / cheri_tag_writer_release, if no more updates need
+ * to happen. Otherwise, using tag get / set / invalidate with an input will
+ * release a lock. Finally, if exceptions may occur, use push_free_on_exception
+ * before such an exception, and pop_free_on_exception after the possibly
+ * exception throwing behavior is finished.
+ */
+
+// Opaque types for locks
+typedef void *tag_reader_lock_t;
+typedef void *tag_writer_lock_t;
+
+// A magic value meaning there is no lock for a particular tag
+// Useful to be different from NULL.
+#define TAG_LOCK_NONE ((void *)-1)
+// This is a lock indicating some kind of error in lookup that got supressed
+#define TAG_LOCK_ERROR ((void *)-2)
+
+// If we for some reason require a tag for untagged memory
+void get_dummy_locks(target_ulong vaddr, tag_writer_lock_t *low,
+                     tag_writer_lock_t *high);
+
+extern tag_writer_lock_t notag_lock_high;
+
+void cheri_tag_reader_lock_impl(tag_reader_lock_t lock);
+void cheri_tag_writer_lock_impl(tag_writer_lock_t lock);
+
+static inline void cheri_tag_reader_release(tag_reader_lock_t lock)
+{
+    if (lock != TAG_LOCK_NONE && lock != NULL)
+        cheri_tag_reader_lock_impl(lock);
+}
+
+static inline void cheri_tag_writer_release(tag_writer_lock_t lock)
+{
+    if (lock != TAG_LOCK_NONE && lock != NULL)
+        cheri_tag_writer_lock_impl(lock);
+}
+
+static inline cheri_exception_locks_t *
+cheri_get_exception_locks(CPUArchState *env)
+{
+    return &env_cpu(env)->cheri_exception_locks;
+}
+
+static inline void cheri_tag_push_free_on_exception(CPUArchState *env,
+                                                    tag_lock_t lock)
+{
+    if (tagmem_use_locking()) {
+        cheri_exception_locks_t *locks = cheri_get_exception_locks(env);
+        assert(locks->fill != MAX_CHERI_EXCEPTION_LOCKS);
+        locks->locks[locks->fill++] = lock;
+    }
+}
+
+static inline tag_lock_t cheri_tag_pop_on_exception(CPUArchState *env)
+{
+    if (tagmem_use_locking()) {
+        cheri_exception_locks_t *locks = cheri_get_exception_locks(env);
+        assert(locks->fill != 0);
+        tag_lock_t lock = locks->locks[--locks->fill];
+        locks->locks[locks->fill] = NULL;
+        return lock;
+    }
+    return NULL;
+}
+
+void cheri_tag_free_lock(tag_lock_t lock);
+
+static inline void cheri_tag_locks_exception_thrown(CPUState *cpu)
+{
+    if (!tagmem_use_locking())
+        return;
+    cheri_exception_locks_t *locks = &cpu->cheri_exception_locks;
+    for (size_t i = 0; i != MAX_CHERI_EXCEPTION_LOCKS; i++) {
+        if (locks->locks[i] && locks->locks[i] != TAG_LOCK_NONE)
+            cheri_tag_free_lock(locks->locks[i]);
+        locks->locks[i] = NULL;
+    }
+    locks->fill = 0;
+}
+
+static inline void
+cheri_tag_reader_push_free_on_exception(CPUArchState *env,
+                                        tag_reader_lock_t lock)
+{
+    cheri_tag_push_free_on_exception(env, (tag_lock_t)lock);
+}
+
+static inline void
+cheri_tag_writer_push_free_on_exception(CPUArchState *env,
+                                        tag_writer_lock_t lock)
+{
+    cheri_tag_push_free_on_exception(env, (tag_lock_t)lock);
+}
+
+static inline tag_reader_lock_t
+cheri_tag_reader_pop_free_on_exception(CPUArchState *env)
+{
+    return (tag_reader_lock_t)cheri_tag_pop_on_exception(env);
+}
+
+static inline tag_writer_lock_t
+cheri_tag_writer_pop_free_on_exception(CPUArchState *env)
+{
+    return (tag_writer_lock_t)cheri_tag_pop_on_exception(env);
+}
+
+#define cheri_tag_assert_not_mttcg() assert(!qemu_tcg_mttcg_enabled());
+
 /* Note: for cheri_tag_phys_invalidate, env may be NULL */
 void cheri_tag_phys_invalidate(CPUArchState *env, RAMBlock *ram,
                                ram_addr_t offset, size_t len,
                                const target_ulong *vaddr);
-void cheri_tag_init(MemoryRegion* mr, uint64_t memory_size);
+void cheri_tag_init(MemoryRegion *mr, uint64_t memory_size);
+
 /**
  * Generic tag invalidation function to be called for a *single* data store:
  * Note: this will currently invalidate at most two tags (as can happen
  * for a unaligned store that crosses a CHERI_CAP_SIZE alignment boundary).
  */
-void cheri_tag_invalidate(CPUArchState *env, target_ulong vaddr, int32_t size,
-                          uintptr_t pc, int mmu_idx);
+void cheri_tag_invalidate_impl(CPUArchState *env, target_ulong vaddr,
+                               int32_t size, uintptr_t pc, int mmu_idx,
+                               tag_writer_lock_t *first,
+                               tag_writer_lock_t *second, bool lock_only);
+
+static inline void cheri_tag_invalidate(CPUArchState *env, target_ulong vaddr,
+                                        int32_t size, uintptr_t pc, int mmu_idx,
+                                        tag_writer_lock_t *first,
+                                        tag_writer_lock_t *second)
+{
+    cheri_tag_invalidate_impl(env, vaddr, size, pc, mmu_idx, first, second,
+                              false);
+}
+
+static inline void cheri_lock_for_tag_invalidate(
+    CPUArchState *env, target_ulong vaddr, int32_t size, uintptr_t pc,
+    int mmu_idx, tag_writer_lock_t *first, tag_writer_lock_t *second)
+{
+    if (!tagmem_use_locking()) {
+        if (first)
+            *first = NULL;
+        if (second)
+            *second = NULL;
+    } else {
+        cheri_tag_invalidate_impl(env, vaddr, size, pc, mmu_idx, first, second,
+                                  true);
+    }
+}
+
+/**
+ * If probe_read() has already been called, the result can be passed as the
+ * @p host_addr argument to avoid another (expensive) probe_read() call.
+ */
+
+void *cheri_tag_invalidate_aligned_impl(CPUArchState *env, target_ulong vaddr,
+                                        uintptr_t pc, int mmu_idx,
+                                        tag_writer_lock_t *lock,
+                                        bool lock_only);
+
 /**
  * Like cheri_tag_invalidate, but the address must be aligned and it will only
  * invalidate a single tag (i.e. no unaligned accesses). A bit faster since it
  * can avoid some branches.
  * @return the host address as returned by probe_write().
  */
-void *cheri_tag_invalidate_aligned(CPUArchState *env, target_ulong vaddr,
-                                   uintptr_t pc, int mmu_idx);
-/**
- * If probe_read() has already been called, the result can be passed as the
- * @p host_addr argument to avoid another (expensive) probe_read() call.
- */
+static inline void *cheri_tag_invalidate_aligned(CPUArchState *env,
+                                                 target_ulong vaddr,
+                                                 uintptr_t pc, int mmu_idx,
+                                                 tag_writer_lock_t *lock)
+{
+    return cheri_tag_invalidate_aligned_impl(env, vaddr, pc, mmu_idx, lock,
+                                             false);
+}
+
+static inline void *
+cheri_lock_for_tag_invalidate_aligned(CPUArchState *env, target_ulong vaddr,
+                                      uintptr_t pc, int mmu_idx,
+                                      tag_writer_lock_t *lock)
+{
+    if (!tagmem_use_locking()) {
+        *lock = NULL;
+        return NULL;
+    } else {
+        return cheri_tag_invalidate_aligned_impl(env, vaddr, pc, mmu_idx, lock,
+                                                 true);
+    }
+}
+
+/* Get a single tag */
+
 bool cheri_tag_get(CPUArchState *env, target_ulong vaddr, int reg,
                    hwaddr *ret_paddr, int *prot, uintptr_t pc, int mmu_idx,
-                   void *host_addr);
-/*
- * Get/set many currently don't have an mmu_idx because no targets currently
- * require it.
+                   void *host_addr, tag_reader_lock_t *lock);
+
+static inline void cheri_lock_for_tag_get(CPUArchState *env, target_ulong vaddr,
+                                          int reg, hwaddr *ret_paddr, int *prot,
+                                          uintptr_t pc, int mmu_idx,
+                                          void *host_addr,
+                                          tag_reader_lock_t *lock)
+{
+    if (!tagmem_use_locking()) {
+        *lock = NULL;
+    } else {
+        cheri_tag_get(env, vaddr, reg, ret_paddr, prot, pc, mmu_idx, host_addr,
+                      lock);
+    }
+}
+
+/* Set a tag to one
+ * @return the host address as returned by probe_cap_write()
  */
-int cheri_tag_get_many(CPUArchState *env, target_ulong vaddr, int reg,
-                       hwaddr *ret_paddr, uintptr_t pc);
-void cheri_tag_set_many(CPUArchState *env, uint32_t tags, target_ulong vaddr,
-                        int reg, hwaddr *ret_paddr, uintptr_t pc);
+void *cheri_tag_set_impl(CPUArchState *env, target_ulong vaddr, int reg,
+                         hwaddr *ret_paddr, uintptr_t pc, int mmu_idx,
+                         tag_writer_lock_t *lock, bool lock_only);
 
 /**
  * Update a tag for virtual address @vaddr.
  * @return the host address as returned by probe_cap_write()
  */
-void *cheri_tag_set(CPUArchState *env, target_ulong vaddr, int reg,
-                    hwaddr *ret_paddr, uintptr_t pc, int mmu_idx);
+static inline void *cheri_tag_set(CPUArchState *env, target_ulong vaddr,
+                                  int reg, hwaddr *ret_paddr, uintptr_t pc,
+                                  int mmu_idx, tag_writer_lock_t *lock)
+{
+    return cheri_tag_set_impl(env, vaddr, reg, ret_paddr, pc, mmu_idx, lock,
+                              false);
+}
+
+static inline void cheri_lock_for_tag_set(CPUArchState *env, target_ulong vaddr,
+                                          int reg, hwaddr *ret_paddr,
+                                          uintptr_t pc, int mmu_idx,
+                                          tag_writer_lock_t *lock)
+{
+    if (!tagmem_use_locking()) {
+        *lock = NULL;
+    } else {
+        cheri_tag_set_impl(env, vaddr, reg, ret_paddr, pc, mmu_idx, lock, true);
+    }
+}
+
+/* Get and set many do not take any locks, as they are not meant for use in
+ * conjunction with modififying data. They are atomic where possible, but
+ * no guarantee is made
+ * Get/set many currently don't have an mmu_idx because no targets currently
+ * require it. */
+
+int cheri_tag_get_many(CPUArchState *env, target_ulong vaddr, int reg,
+                       hwaddr *ret_paddr, uintptr_t pc);
+void cheri_tag_set_many(CPUArchState *env, uint32_t tags, target_ulong vaddr,
+                        int reg, hwaddr *ret_paddr, uintptr_t pc);
 
 void *cheri_tagmem_for_addr(CPUArchState *env, target_ulong vaddr,
                             RAMBlock *ram, ram_addr_t ram_offset, size_t size,
                             int *prot, bool tag_write);
+
+#else /* !TARGET_CHERI */
+
+#define cheri_tag_locks_exception_thrown(...)
+
 #endif /* TARGET_CHERI */

--- a/target/cheri-common/cheri_tagmem_ex_locks.h
+++ b/target/cheri-common/cheri_tagmem_ex_locks.h
@@ -47,6 +47,4 @@ typedef struct cheri_exception_locks_t {
     int fill;
 } cheri_exception_locks_t;
 
-#define CHERI_EXCEPTION_LOCKS cheri_exception_locks_t cheri_exception_locks;
-
 #endif // QEMU_CHERI_TAGMEM_EX_LOCKS_H

--- a/target/cheri-common/cheri_tagmem_ex_locks.h
+++ b/target/cheri-common/cheri_tagmem_ex_locks.h
@@ -1,0 +1,52 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2021 Lawrence Esswood
+ *
+ * This work was supported by Innovate UK project 105694, "Digital Security
+ * by Design (DSbD) Technology Platform Prototype".
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef QEMU_CHERI_TAGMEM_EX_LOCKS_H
+#define QEMU_CHERI_TAGMEM_EX_LOCKS_H
+
+typedef void *tag_lock_t;
+
+/* These will likely be TCG globals when we migrate to using fewer helpers.
+ * We can actually tell what kind of lock a lock is as reads/writes are
+ * exclusive, so we do not actually need two different queues.
+ */
+
+#define MAX_CHERI_EXCEPTION_LOCKS 2
+typedef struct cheri_exception_locks_t {
+    tag_lock_t locks[MAX_CHERI_EXCEPTION_LOCKS];
+    /* note: this index is just for push/pop. On an exception it is ignored,
+     * and any non-null value in the lock array is freed.
+     */
+    int fill;
+} cheri_exception_locks_t;
+
+#define CHERI_EXCEPTION_LOCKS cheri_exception_locks_t cheri_exception_locks;
+
+#endif // QEMU_CHERI_TAGMEM_EX_LOCKS_H

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -205,8 +205,10 @@ void CHERI_HELPER_IMPL(cheri_invalidate_tags(CPUArchState *env,
                                              target_ulong vaddr,
                                              TCGMemOpIdx oi))
 {
+    /* Should only be used when locking is off */
+    tcg_debug_assert(!parallel_cpus);
     cheri_tag_invalidate(env, vaddr, memop_size(get_memop(oi)), GETPC(),
-                         get_mmuidx(oi));
+                         get_mmuidx(oi), NULL, NULL);
 }
 
 /*
@@ -216,10 +218,82 @@ void CHERI_HELPER_IMPL(cheri_invalidate_tags(CPUArchState *env,
 void CHERI_HELPER_IMPL(cheri_invalidate_tags_condition(
     CPUArchState *env, target_ulong vaddr, TCGMemOpIdx oi, uint32_t cond))
 {
+    tcg_debug_assert(!parallel_cpus);
     if (cond) {
         cheri_tag_invalidate(env, vaddr, memop_size(get_memop(oi)), GETPC(),
-                             get_mmuidx(oi));
+                             get_mmuidx(oi), NULL, NULL);
     }
+}
+
+/* These versions take (possibly two) locks, and also register them to be freed
+ * On an exception
+ */
+
+void CHERI_HELPER_IMPL(cheri_invalidate_lock_tags_start(CPUArchState *env,
+                                                        target_ulong vaddr,
+                                                        TCGMemOpIdx oi))
+{
+    tag_writer_lock_t low = NULL;
+    tag_writer_lock_t high = NULL;
+    cheri_lock_for_tag_invalidate(env, vaddr, memop_size(get_memop(oi)),
+                                  GETPC(), get_mmuidx(oi), &low, &high);
+    cheri_tag_writer_push_free_on_exception(env, low);
+    cheri_tag_writer_push_free_on_exception(env, high);
+}
+
+/* If using the lock to protect a standard atomic, then we always need a lock */
+void CHERI_HELPER_IMPL(cheri_invalidate_lock_tags_start_or_dummy(
+    CPUArchState *env, target_ulong vaddr, TCGMemOpIdx oi))
+{
+    tag_writer_lock_t low = NULL;
+    tag_writer_lock_t high = NULL;
+    cheri_lock_for_tag_invalidate(env, vaddr, memop_size(get_memop(oi)),
+                                  GETPC(), get_mmuidx(oi), &low, &high);
+    if (low == TAG_LOCK_NONE || high == TAG_LOCK_NONE)
+        get_dummy_locks(vaddr, &low, &high);
+
+    cheri_tag_writer_push_free_on_exception(env, low);
+    cheri_tag_writer_push_free_on_exception(env, high);
+}
+
+void CHERI_HELPER_IMPL(cheri_invalidate_lock_tags_end(CPUArchState *env,
+                                                      target_ulong vaddr,
+                                                      TCGMemOpIdx oi))
+{
+    tag_writer_lock_t high = cheri_tag_writer_pop_free_on_exception(env);
+    tag_writer_lock_t low = cheri_tag_writer_pop_free_on_exception(env);
+    cheri_tag_invalidate(env, vaddr, memop_size(get_memop(oi)), GETPC(),
+                         get_mmuidx(oi), &low, &high);
+}
+
+void CHERI_HELPER_IMPL(cheri_invalidate_lock_tags_end_condition(
+    CPUArchState *env, target_ulong vaddr, TCGMemOpIdx oi, uint32_t cond))
+{
+    tag_writer_lock_t high = cheri_tag_writer_pop_free_on_exception(env);
+    tag_writer_lock_t low = cheri_tag_writer_pop_free_on_exception(env);
+    if (cond)
+        cheri_tag_invalidate(env, vaddr, memop_size(get_memop(oi)), GETPC(),
+                             get_mmuidx(oi), &low, &high);
+    else {
+        cheri_tag_writer_release(high);
+        cheri_tag_writer_release(low);
+    }
+}
+
+/* Assert that there was actually a tag lock taken (for debugging) */
+void CHERI_HELPER_IMPL(cheri_invalidate_lock_tags_assert_exist(
+    CPUArchState *env, target_ulong vaddr))
+{
+    tag_writer_lock_t high = cheri_tag_writer_pop_free_on_exception(env);
+    tag_writer_lock_t low = cheri_tag_writer_pop_free_on_exception(env);
+
+    if (!(low != NULL && low != TAG_LOCK_NONE)) {
+        printf("Addr: " TARGET_FMT_lx ". Low: %p. High %p\n", vaddr, low, high);
+        assert(0);
+    }
+
+    cheri_tag_writer_push_free_on_exception(env, low);
+    cheri_tag_writer_push_free_on_exception(env, high);
 }
 
 /// Implementations of individual instructions start here
@@ -1183,7 +1257,7 @@ void CHERI_HELPER_IMPL(load_cap_via_cap(CPUArchState *env, uint32_t cd,
         cbp, CHERI_CAP_SIZE, raise_unaligned_load_exception);
 
     load_cap_from_memory(env, cd, cb, cbp, addr, _host_return_address,
-                         /*physaddr_out=*/NULL);
+                         /*physaddr_out=*/NULL, true);
 }
 
 void CHERI_HELPER_IMPL(store_cap_via_cap(CPUArchState *env, uint32_t cs,
@@ -1200,7 +1274,7 @@ void CHERI_HELPER_IMPL(store_cap_via_cap(CPUArchState *env, uint32_t cs,
                              CHERI_CAP_SIZE, _host_return_address, cbp,
                              CHERI_CAP_SIZE, raise_unaligned_store_exception);
 
-    store_cap_to_memory(env, cs, addr, _host_return_address);
+    store_cap_to_memory(env, cs, addr, _host_return_address, true);
 }
 
 static inline bool
@@ -1241,7 +1315,7 @@ void squash_mutable_permissions(CPUArchState *env, target_ulong *pesbt,
 bool load_cap_from_memory_raw_tag_mmu_idx(
     CPUArchState *env, target_ulong *pesbt, target_ulong *cursor, uint32_t cb,
     const cap_register_t *source, target_ulong vaddr, target_ulong retpc,
-    hwaddr *physaddr, bool *raw_tag, int mmu_idx)
+    hwaddr *physaddr, bool take_lock, bool *raw_tag, int mmu_idx)
 {
     cheri_debug_assert(QEMU_IS_ALIGNED(vaddr, CHERI_CAP_SIZE));
     /*
@@ -1252,6 +1326,15 @@ bool load_cap_from_memory_raw_tag_mmu_idx(
      */
     /* No TLB fault possible, should be safe to get a host pointer now */
     void *host = probe_read(env, vaddr, CHERI_CAP_SIZE, mmu_idx, retpc);
+
+    tag_reader_lock_t read_lock = NULL;
+    int prot;
+
+    if (take_lock) {
+        cheri_lock_for_tag_get(env, vaddr, cb, physaddr, &prot, retpc, mmu_idx,
+                               host, &read_lock);
+    }
+
     // When writing back pesbt we have to XOR with the NULL mask to ensure that
     // NULL capabilities have an all-zeroes representation.
     if (likely(host)) {
@@ -1269,17 +1352,26 @@ bool load_cap_from_memory_raw_tag_mmu_idx(
 #undef ld_cap_word_p
     } else {
         // Slow path for e.g. IO regions.
+        if (take_lock)
+            cheri_tag_reader_push_free_on_exception(env, read_lock);
         qemu_maybe_log_instr_extra(env, "Using slow path for load from guest "
             "address " TARGET_FMT_lx "\n", vaddr);
         *pesbt = cpu_ld_cap_word_ra(env, vaddr + CHERI_MEM_OFFSET_METADATA, retpc) ^
                 CAP_NULL_XOR_MASK;
         *cursor = cpu_ld_cap_word_ra(env, vaddr + CHERI_MEM_OFFSET_CURSOR, retpc);
+        if (take_lock)
+            cheri_tag_reader_pop_free_on_exception(env);
     }
-    int prot;
-    bool tag =
-        cheri_tag_get(env, vaddr, cb, physaddr, &prot, retpc, mmu_idx, host);
-    if (raw_tag) {
+
+    bool tag = cheri_tag_get(env, vaddr, cb, physaddr, &prot, retpc, mmu_idx,
+                             host, take_lock ? &read_lock : NULL);
+
+    if (raw_tag)
         *raw_tag = tag;
+
+    if (tag) {
+        tag = cheri_tag_prot_clear_or_trap(env, vaddr, cb, source, prot, retpc,
+                                           tag);
     }
     tag =
         cheri_tag_prot_clear_or_trap(env, vaddr, cb, source, prot, retpc, tag);
@@ -1320,29 +1412,31 @@ bool load_cap_from_memory_raw_tag(CPUArchState *env, target_ulong *pesbt,
                                   target_ulong *cursor, uint32_t cb,
                                   const cap_register_t *source,
                                   target_ulong vaddr, target_ulong retpc,
-                                  hwaddr *physaddr, bool *raw_tag)
+                                  hwaddr *physaddr, bool take_lock,
+                                  bool *raw_tag)
 {
-    return load_cap_from_memory_raw_tag_mmu_idx(env, pesbt, cursor, cb, source,
-                                                vaddr, retpc, physaddr, raw_tag,
-                                                cpu_mmu_index(env, false));
+    return load_cap_from_memory_raw_tag_mmu_idx(
+        env, pesbt, cursor, cb, source, vaddr, retpc, physaddr, take_lock,
+        raw_tag, cpu_mmu_index(env, false));
 }
 
 bool load_cap_from_memory_raw(CPUArchState *env, target_ulong *pesbt,
                               target_ulong *cursor, uint32_t cb,
                               const cap_register_t *source, target_ulong vaddr,
-                              target_ulong retpc, hwaddr *physaddr)
+                              target_ulong retpc, hwaddr *physaddr,
+                              bool take_lock)
 {
     return load_cap_from_memory_raw_tag(env, pesbt, cursor, cb, source, vaddr,
-                                        retpc, physaddr, NULL);
+                                        retpc, physaddr, take_lock, NULL);
 }
 
 cap_register_t load_and_decompress_cap_from_memory_raw(
     CPUArchState *env, uint32_t cb, const cap_register_t *source,
-    target_ulong vaddr, target_ulong retpc, hwaddr *physaddr)
+    target_ulong vaddr, target_ulong retpc, hwaddr *physaddr, bool take_lock)
 {
     target_ulong pesbt, cursor;
     bool tag = load_cap_from_memory_raw(env, &pesbt, &cursor, cb, source, vaddr,
-                                        retpc, physaddr);
+                                        retpc, physaddr, take_lock);
     cap_register_t result;
     CAP_cc(decompress_raw)(pesbt, cursor, tag, &result);
     result.cr_extra = CREG_FULLY_DECOMPRESSED;
@@ -1351,18 +1445,18 @@ cap_register_t load_and_decompress_cap_from_memory_raw(
 
 void load_cap_from_memory(CPUArchState *env, uint32_t cd, uint32_t cb,
                           const cap_register_t *source, target_ulong vaddr,
-                          target_ulong retpc, hwaddr *physaddr)
+                          target_ulong retpc, hwaddr *physaddr, bool take_lock)
 {
     target_ulong pesbt;
     target_ulong cursor;
     bool tag = load_cap_from_memory_raw(env, &pesbt, &cursor, cb, source, vaddr,
-                                        retpc, physaddr);
+                                        retpc, physaddr, take_lock);
     update_compressed_capreg(env, cd, pesbt, tag, cursor);
 }
 
 void store_cap_to_memory_mmu_index(CPUArchState *env, uint32_t cs,
                                    target_ulong vaddr, target_ulong retpc,
-                                   int mmu_idx)
+                                   int mmu_idx, bool take_lock)
 {
     target_ulong cursor = get_capreg_cursor(env, cs);
     target_ulong pesbt_for_mem = get_capreg_pesbt(env, cs) ^ CAP_NULL_XOR_MASK;
@@ -1384,14 +1478,17 @@ void store_cap_to_memory_mmu_index(CPUArchState *env, uint32_t cs,
      * accidentally tagging a shorn data write.  This, like the rest of the
      * tag logic, is not multi-TCG-thread safe.
      */
+    tag_writer_lock_t lock = NULL;
 
     env->statcounters_cap_write++;
     void *host = NULL;
     if (tag) {
         env->statcounters_cap_write_tagged++;
-        host = cheri_tag_set(env, vaddr, cs, NULL, retpc, mmu_idx);
+        host = cheri_tag_set(env, vaddr, cs, NULL, retpc, mmu_idx,
+                             take_lock ? &lock : NULL);
     } else {
-        host = cheri_tag_invalidate_aligned(env, vaddr, retpc, mmu_idx);
+        host = cheri_tag_invalidate_aligned(env, vaddr, retpc, mmu_idx,
+                                            take_lock ? &lock : NULL);
     }
     // When writing back pesbt we have to XOR with the NULL mask to ensure that
     // NULL capabilities have an all-zeroes representation.
@@ -1409,13 +1506,18 @@ void store_cap_to_memory_mmu_index(CPUArchState *env, uint32_t cs,
 #undef st_cap_word_p
     } else {
         // Slow path for e.g. IO regions.
+        cheri_tag_writer_push_free_on_exception(env, lock);
         qemu_maybe_log_instr_extra(env, "Using slow path for store to guest "
             "address " TARGET_FMT_lx "\n", vaddr);
         cpu_st_cap_word_ra(env, vaddr + CHERI_MEM_OFFSET_METADATA,
                            pesbt_for_mem, retpc);
         cpu_st_cap_word_ra(env, vaddr + CHERI_MEM_OFFSET_CURSOR, cursor,
                            retpc);
+        cheri_tag_writer_pop_free_on_exception(lock);
     }
+
+    cheri_tag_writer_release(lock);
+
 #if defined(TARGET_RISCV) && defined(CONFIG_RVFI_DII)
     env->rvfi_dii_trace.MEM.rvfi_mem_addr = vaddr;
     env->rvfi_dii_trace.MEM.rvfi_mem_wdata[0] = cursor;
@@ -1442,10 +1544,10 @@ void store_cap_to_memory_mmu_index(CPUArchState *env, uint32_t cs,
 }
 
 void store_cap_to_memory(CPUArchState *env, uint32_t cs, target_ulong vaddr,
-                         target_ulong retpc)
+                         target_ulong retpc, bool take_lock)
 {
     return store_cap_to_memory_mmu_index(env, cs, vaddr, retpc,
-                                         cpu_mmu_index(env, false));
+                                         cpu_mmu_index(env, false), take_lock);
 }
 
 target_ulong CHERI_HELPER_IMPL(cloadtags(CPUArchState *env, uint32_t cb))

--- a/target/mips/op_helper.c
+++ b/target/mips/op_helper.c
@@ -377,18 +377,22 @@ static inline target_ulong ccheck_store_right(CPUMIPSState *env, target_ulong of
     // return the actual address by adding the low bits (this is expected by translate.c
     return check_ddc(env, CAP_PERM_STORE, write_offset, stored_bytes, retpc) + low_bits;
 }
+
+// swr/sdr/swl/sdl will never invalidate more than one capability
+#define invalidate_tags_store_left_right_start(env, addr, retpc, mem_idx)      \
+    tag_writer_lock_t writer_lock = NULL;                                      \
+    cheri_lock_for_tag_invalidate(env, addr, 1, retpc, mem_idx, &writer_lock,  \
+                                  NULL)
+
+#define invalidate_tags_store_left_right_end(env, addr, retpc, mem_idx)        \
+    cheri_tag_invalidate(env, addr, 1, retpc, mem_idx, &writer_lock, NULL)
+
+#else // !TARGET_CHERI
+
+#define invalidate_tags_store_left_right_start(env, addr, retpc, mem_idx)
+#define invalidate_tags_store_left_right_end(env, addr, retpc, mem_idx)
+
 #endif
-
-static inline void invalidate_tags_store_left_right(CPUMIPSState *env,
-                                                    target_ulong addr,
-                                                    uintptr_t retpc) {
-#ifdef TARGET_CHERI
-    // swr/sdr/swl/sdl will never invalidate more than one capability
-    cheri_tag_invalidate(env, addr, 1, retpc, cpu_mmu_index(env, false));
-#endif
-}
-
-
 
 void helper_swl(CPUMIPSState *env, target_ulong arg1, target_ulong arg2,
                 int mem_idx)
@@ -397,6 +401,8 @@ void helper_swl(CPUMIPSState *env, target_ulong arg1, target_ulong arg2,
     const int num_bytes = 4 - GET_LMASK(arg2);
     arg2 = check_ddc(env, CAP_PERM_STORE, arg2, num_bytes, GETPC());
 #endif
+    invalidate_tags_store_left_right_start(env, arg2, GETPC(), mem_idx);
+
     cpu_stb_mmuidx_ra(env, arg2, (uint8_t)(arg1 >> 24), mem_idx, GETPC());
 
     if (GET_LMASK(arg2) <= 2) {
@@ -413,7 +419,7 @@ void helper_swl(CPUMIPSState *env, target_ulong arg1, target_ulong arg2,
         cpu_stb_mmuidx_ra(env, GET_OFFSET(arg2, 3), (uint8_t)arg1,
                           mem_idx, GETPC());
     }
-    invalidate_tags_store_left_right(env, arg2, GETPC());
+    invalidate_tags_store_left_right_end(env, arg2, GETPC(), mem_idx);
 }
 
 void helper_swr(CPUMIPSState *env, target_ulong arg1, target_ulong arg2,
@@ -421,6 +427,7 @@ void helper_swr(CPUMIPSState *env, target_ulong arg1, target_ulong arg2,
 #ifdef TARGET_CHERI
     arg2 = ccheck_store_right(env, arg2, 4, GETPC());
 #endif
+    invalidate_tags_store_left_right_start(env, arg2, GETPC(), mem_idx);
     cpu_stb_mmuidx_ra(env, arg2, (uint8_t)arg1, mem_idx, GETPC());
 
     if (GET_LMASK(arg2) >= 1) {
@@ -437,7 +444,7 @@ void helper_swr(CPUMIPSState *env, target_ulong arg1, target_ulong arg2,
         cpu_stb_mmuidx_ra(env, GET_OFFSET(arg2, -3), (uint8_t)(arg1 >> 24),
                           mem_idx, GETPC());
     }
-    invalidate_tags_store_left_right(env, arg2, GETPC());
+    invalidate_tags_store_left_right_end(env, arg2, GETPC(), mem_idx);
 }
 
 #if defined(TARGET_MIPS64)
@@ -455,9 +462,11 @@ void helper_sdl(CPUMIPSState *env, target_ulong arg1, target_ulong arg2,
                 int mem_idx)
 {
 #ifdef TARGET_CHERI
-    const int num_bytes = 4 - GET_LMASK(arg2);
+    const int num_bytes = 8 - GET_LMASK(arg2);
     arg2 = check_ddc(env, CAP_PERM_STORE, arg2, num_bytes, GETPC());
 #endif
+    invalidate_tags_store_left_right_start(env, arg2, GETPC(), mem_idx);
+
     cpu_stb_mmuidx_ra(env, arg2, (uint8_t)(arg1 >> 56), mem_idx, GETPC());
 
     if (GET_LMASK64(arg2) <= 6) {
@@ -494,7 +503,7 @@ void helper_sdl(CPUMIPSState *env, target_ulong arg1, target_ulong arg2,
         cpu_stb_mmuidx_ra(env, GET_OFFSET(arg2, 7), (uint8_t)arg1,
                           mem_idx, GETPC());
     }
-    invalidate_tags_store_left_right(env, arg2, GETPC());
+    invalidate_tags_store_left_right_end(env, arg2, GETPC(), mem_idx);
 }
 
 void helper_sdr(CPUMIPSState *env, target_ulong arg1, target_ulong arg2,
@@ -503,6 +512,8 @@ void helper_sdr(CPUMIPSState *env, target_ulong arg1, target_ulong arg2,
 #ifdef TARGET_CHERI
     arg2 = ccheck_store_right(env, arg2, 8, GETPC());
 #endif
+    invalidate_tags_store_left_right_start(env, arg2, GETPC(), mem_idx);
+
     cpu_stb_mmuidx_ra(env, arg2, (uint8_t)arg1, mem_idx, GETPC());
 
     if (GET_LMASK64(arg2) >= 1) {
@@ -539,7 +550,7 @@ void helper_sdr(CPUMIPSState *env, target_ulong arg1, target_ulong arg2,
         cpu_stb_mmuidx_ra(env, GET_OFFSET(arg2, -7), (uint8_t)(arg1 >> 56),
                           mem_idx, GETPC());
     }
-    invalidate_tags_store_left_right(env, arg2, GETPC());
+    invalidate_tags_store_left_right_end(env, arg2, GETPC(), mem_idx);
 }
 #endif /* TARGET_MIPS64 */
 
@@ -1892,11 +1903,18 @@ static inline void
 store_byte_and_clear_tag(CPUMIPSState *env, target_ulong vaddr, uint8_t val,
                          TCGMemOpIdx oi, uintptr_t retaddr)
 {
+#ifdef TARGET_CHERI
+    tag_writer_lock_t lock = NULL;
+    cheri_lock_for_tag_invalidate(env, vaddr, 1, retaddr, get_mmuidx(oi), &lock,
+                                  NULL);
+    cheri_tag_writer_push_free_on_exception(env, lock);
+#endif
     helper_ret_stb_mmu(env, vaddr, val, oi, retaddr);
 #ifdef TARGET_CHERI
+    cheri_tag_writer_pop_free_on_exception(env);
     // If we returned (i.e. write was successful) we also need to invalidate the
     // tags bit to ensure we are consistent with sb
-    cheri_tag_invalidate(env, vaddr, 1, retaddr, cpu_mmu_index(env, false));
+    cheri_tag_invalidate(env, vaddr, 1, retaddr, get_mmuidx(oi), &lock, NULL);
 #endif
 }
 
@@ -1904,11 +1922,19 @@ static inline void
 store_u32_and_clear_tag(CPUMIPSState *env, target_ulong vaddr, uint32_t val,
                          TCGMemOpIdx oi, uintptr_t retaddr)
 {
+#ifdef TARGET_CHERI
+    tag_writer_lock_t lock = NULL;
+    tag_writer_lock_t lock2 = NULL;
+    cheri_lock_for_tag_invalidate(env, vaddr, 4, retaddr, get_mmuidx(oi), &lock,
+                                  &lock2);
+    cheri_tag_writer_push_free_on_exception(env, lock);
+#endif
     helper_ret_stw_mmu(env, vaddr, val, oi, retaddr);
 #ifdef TARGET_CHERI
+    cheri_tag_writer_pop_free_on_exception(env);
     // If we returned (i.e. write was successful) we also need to invalidate the
     // tags bit to ensure we are consistent with sb
-    cheri_tag_invalidate(env, vaddr, 4, retaddr, cpu_mmu_index(env, false));
+    cheri_tag_invalidate(env, vaddr, 4, retaddr, get_mmuidx(oi), &lock, &lock2);
 #endif
 }
 

--- a/target/mips/op_helper_cheri.c
+++ b/target/mips/op_helper_cheri.c
@@ -693,7 +693,7 @@ target_ulong CHERI_HELPER_IMPL(cscc_without_tcg(CPUArchState *env, uint32_t cs, 
         vaddr, env->lladdr, env->CP0_LLAddr);
     if (env->lladdr != vaddr)
         return 0;
-    store_cap_to_memory(env, cs, vaddr, retpc);
+    store_cap_to_memory(env, cs, vaddr, retpc, true);
     env->lladdr = 1;
     return 1;
 }
@@ -723,7 +723,7 @@ void CHERI_HELPER_IMPL(cllc_without_tcg(CPUArchState *env, uint32_t cd, uint32_t
     }
     cheri_debug_assert(align_of(CHERI_CAP_SIZE, addr) == 0);
     load_cap_from_memory(env, cd, cb, cbp, /*addr=*/cap_get_cursor(cbp),
-                         _host_return_address, &env->CP0_LLAddr);
+                         _host_return_address, &env->CP0_LLAddr, true);
     env->lladdr = addr;
 }
 

--- a/target/riscv/op_helper_cheri.c
+++ b/target/riscv/op_helper_cheri.c
@@ -284,12 +284,22 @@ void HELPER(amoswap_cap)(CPUArchState *env, uint32_t dest_reg,
     // load_cap_from_memory call overwrites that register
     target_ulong loaded_pesbt;
     target_ulong loaded_cursor;
+
+    tag_writer_lock_t lock = NULL;
+
+    cheri_lock_for_tag_set(env, addr, addr_reg, NULL, _host_return_address,
+                           cpu_mmu_index(env, false), &lock);
+    cheri_tag_writer_push_free_on_exception(env, lock);
+
     bool loaded_tag =
         load_cap_from_memory_raw(env, &loaded_pesbt, &loaded_cursor, addr_reg,
-                                 cbp, addr, _host_return_address, NULL);
+                                 cbp, addr, _host_return_address, NULL, false);
     // The store may still trap, so we must only update the dest register after
     // the store succeeded.
-    store_cap_to_memory(env, val_reg, addr, _host_return_address);
+    store_cap_to_memory(env, val_reg, addr, _host_return_address, false);
+    cheri_tag_writer_pop_free_on_exception(env);
+    cheri_tag_writer_release(lock);
+
     // Store succeeded -> we can update cd
     update_compressed_capreg(env, dest_reg, loaded_pesbt, loaded_tag,
                              loaded_cursor);
@@ -323,13 +333,17 @@ static void lr_c_impl(CPUArchState *env, uint32_t dest_reg, uint32_t addr_reg,
     }
     target_ulong pesbt;
     target_ulong cursor;
-    bool tag = load_cap_from_memory_raw(env, &pesbt, &cursor, addr_reg, cbp,
-                                        addr, _host_return_address, NULL);
+    // lr state should use an un-squashed tag, as the value is an emulator hack
+    // and should depend on the actual value in memory.
+    bool raw_tag;
+    bool tag = load_cap_from_memory_raw_tag(env, &pesbt, &cursor, addr_reg, cbp,
+                                            addr, _host_return_address, NULL,
+                                            true, &raw_tag);
     // If this didn't trap, update the lr state:
     env->load_res = addr;
     env->load_val = cursor;
     env->load_pesbt = pesbt;
-    env->load_tag = tag;
+    env->load_tag = raw_tag;
     log_changed_special_reg(env, "load_res", env->load_res);
     log_changed_special_reg(env, "load_val", env->load_val);
     log_changed_special_reg(env, "load_pesbt", env->load_pesbt);
@@ -401,7 +415,9 @@ static target_ulong sc_c_impl(CPUArchState *env, uint32_t addr_reg,
     // We do this regardless of success/failure.
     env->load_res = -1;
     log_changed_special_reg(env, "load_res", env->load_res);
+    bool store_fails;
     if (addr != expected_addr) {
+        store_fails = 1;
         goto sc_failed;
     }
     // Now perform the "cmpxchg" operation by checking if the current values
@@ -413,20 +429,31 @@ static target_ulong sc_c_impl(CPUArchState *env, uint32_t addr_reg,
     // (this is not a real load).
     target_ulong current_pesbt;
     target_ulong current_cursor;
-    bool current_tag =
-        load_cap_from_memory_raw(env, &current_pesbt, &current_cursor, addr_reg,
-                                 cbp, addr, _host_return_address, NULL);
-    if (current_cursor != env->load_val || current_pesbt != env->load_pesbt ||
-        current_tag != env->load_tag) {
-        goto sc_failed;
+    bool current_tag;
+
+    tag_writer_lock_t lock = NULL;
+    cheri_lock_for_tag_set(env, addr, addr_reg, NULL, _host_return_address,
+                           cpu_mmu_index(env, false), &lock);
+    cheri_tag_writer_push_free_on_exception(env, lock);
+
+    load_cap_from_memory_raw_tag(env, &current_pesbt, &current_cursor, addr_reg,
+                                 cbp, addr, _host_return_address, NULL, false,
+                                 &current_tag);
+
+    store_fails = current_cursor != env->load_val ||
+                  current_pesbt != env->load_pesbt ||
+                  current_tag != env->load_tag;
+
+    if (!store_fails) {
+        // This store may still trap, so we should update env->load_res before
+        store_cap_to_memory(env, val_reg, addr, _host_return_address, false);
     }
-    // This store may still trap, so we should update env->load_res before
-    store_cap_to_memory(env, val_reg, addr, _host_return_address);
-    tcg_debug_assert(env->load_res == -1);
-    return 0; // success
+
+    cheri_tag_writer_pop_free_on_exception(env);
+    cheri_tag_writer_release(lock);
 sc_failed:
     tcg_debug_assert(env->load_res == -1);
-    return 1; // failure
+    return store_fails; // success
 }
 
 target_ulong HELPER(sc_c_modedep)(CPUArchState *env, uint32_t addr_reg, uint32_t val_reg)

--- a/target/riscv/op_helper_cheri.c
+++ b/target/riscv/op_helper_cheri.c
@@ -240,9 +240,6 @@ void HELPER(amoswap_cap)(CPUArchState *env, uint32_t dest_reg,
                          uint32_t addr_reg, uint32_t val_reg)
 {
     uintptr_t _host_return_address = GETPC();
-    assert(!qemu_tcg_mttcg_enabled() ||
-           (cpu_in_exclusive_context(env_cpu(env)) &&
-            "Should have raised EXCP_ATOMIC"));
     target_long offset = 0;
     if (!cheri_in_capmode(env)) {
         offset = get_capreg_cursor(env, addr_reg);
@@ -308,9 +305,6 @@ void HELPER(amoswap_cap)(CPUArchState *env, uint32_t dest_reg,
 static void lr_c_impl(CPUArchState *env, uint32_t dest_reg, uint32_t addr_reg,
                       target_long offset, uintptr_t _host_return_address)
 {
-    assert(!qemu_tcg_mttcg_enabled() ||
-           (cpu_in_exclusive_context(env_cpu(env)) &&
-            "Should have raised EXCP_ATOMIC"));
     const cap_register_t *cbp = get_load_store_base_cap(env, addr_reg);
     if (!cbp->cr_tag) {
         raise_cheri_exception(env, CapEx_TagViolation, addr_reg);
@@ -377,9 +371,6 @@ static target_ulong sc_c_impl(CPUArchState *env, uint32_t addr_reg,
                               uint32_t val_reg, target_ulong offset,
                               uintptr_t _host_return_address)
 {
-    assert(!qemu_tcg_mttcg_enabled() ||
-        (cpu_in_exclusive_context(env_cpu(env)) &&
-            "Should have raised EXCP_ATOMIC"));
     const cap_register_t *cbp = get_load_store_base_cap(env, addr_reg);
 
     if (!cbp->cr_tag) {

--- a/target/riscv/op_helper_cheri.c
+++ b/target/riscv/op_helper_cheri.c
@@ -408,7 +408,7 @@ static target_ulong sc_c_impl(CPUArchState *env, uint32_t addr_reg,
     log_changed_special_reg(env, "load_res", env->load_res);
     bool store_fails;
     if (addr != expected_addr) {
-        store_fails = 1;
+        store_fails = true;
         goto sc_failed;
     }
     // Now perform the "cmpxchg" operation by checking if the current values


### PR DESCRIPTION
When MTTCG is enabled, this turns every tag bit into a write-preferring readers-writer lock. When single-threaded, the old one bit per tag is used.

Originally this was based on the morello branch, and so although I have tried to keep it separate, some general fixes I did there have crept in. Namely, the raw_tag version of capability loading (to get the un-squashed tag to implement atomics), and some sign fixes for TCG atomics.