### PR TITLE
cheri-compressed-cap: don't unpack PEBST

### DIFF
--- a/target/cheri-common/cheri-compressed-cap/CMakeLists.txt
+++ b/target/cheri-common/cheri-compressed-cap/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.10)
 project(cheri_compressed_cap C CXX)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 14)
-if(APPLE)
+if(APPLE AND NOT (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
     # XXX: ugly hack, would be nice if llvm could find this
-    include_directories(/Library/Developer/CommandLineTools/usr/include/c++/v1)
+    include_directories(SYSTEM /Library/Developer/CommandLineTools/usr/include/c++/v1)
 endif()
 
 include(CheckCXXCompilerFlag)
@@ -17,8 +17,8 @@ set(CMAKE_REQUIRED_LIBRARIES -fsanitize=memory)
 check_cxx_compiler_flag(-fsanitize=memory HAVE_MSAN)
 # XXX: needs instrumented system libraries
 set(HAVE_MSAN FALSE)
-set(CMAKE_REQUIRED_LIBRARIES -fsanitize=fuzzer-no-link)
-check_cxx_compiler_flag(-fsanitize=fuzzer-no-link HAVE_LIBFUZZER)
+set(CMAKE_REQUIRED_LIBRARIES -fsanitize=fuzzer)
+check_cxx_compiler_flag(-fsanitize=fuzzer HAVE_LIBFUZZER)
 
 if (HAVE_UBSAN)
     add_compile_options(-fsanitize=undefined)

--- a/target/cheri-common/cheri-compressed-cap/decompress_c128_cap.c
+++ b/target/cheri-common/cheri-compressed-cap/decompress_c128_cap.c
@@ -32,7 +32,6 @@
 #include <err.h>
 #include <errno.h>
 #include <inttypes.h>
-#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -55,8 +54,8 @@ static const char* otype_suffix(uint32_t otype) {
 }
 
 static void dump_cap_fields(const cc128_cap_t* result) {
-    fprintf(stderr, "Permissions: 0x%" PRIx32 "\n", result->cr_perms); // TODO: decode perms
-    fprintf(stderr, "User Perms:  0x%" PRIx32 "\n", result->cr_uperms);
+    fprintf(stderr, "Permissions: 0x%" PRIx32 "\n", cc128_get_perms(result)); // TODO: decode perms
+    fprintf(stderr, "User Perms:  0x%" PRIx32 "\n", cc128_get_uperms(result));
     fprintf(stderr, "Base:        0x%016" PRIx64 "\n", result->cr_base);
     fprintf(stderr, "Offset:      0x%016" PRIx64 "\n", result->_cr_cursor - result->cr_base);
     fprintf(stderr, "Cursor:      0x%016" PRIx64 "\n", result->_cr_cursor);
@@ -67,9 +66,10 @@ static void dump_cap_fields(const cc128_cap_t* result) {
     fprintf(stderr, "Top:        0x%" PRIx64 "%016" PRIx64 " %s\n", (uint64_t)(top_full >> 64), (uint64_t)top_full,
             top_full > UINT64_MAX ? " (greater than UINT64_MAX)" : "");
     fprintf(stderr, "Sealed:      %d\n", cc128_is_cap_sealed(result) ? 1 : 0);
-    fprintf(stderr, "OType:       0x%" PRIx32 "%s\n", result->cr_otype, otype_suffix(result->cr_otype));
-    fprintf(stderr, "Flags:       0x%" PRIx8 "\n", result->cr_flags);
-    fprintf(stderr, "Reserved:    0x%" PRIx8 "\n", result->cr_reserved);
+    uint32_t otype = cc128_get_otype(result);
+    fprintf(stderr, "OType:       0x%" PRIx32 "%s\n", otype, otype_suffix(otype));
+    fprintf(stderr, "Flags:       0x%" PRIx8 "\n", cc128_get_flags(result));
+    fprintf(stderr, "Reserved:    0x%" PRIx8 "\n", cc128_get_reserved(result));
     fprintf(stderr, "Valid decompress: %s", result->cr_bounds_valid ? "yes" : "no");
     fprintf(stderr, "\n");
 }

--- a/target/cheri-common/cheri-compressed-cap/test/fuzz-decompress.cpp
+++ b/target/cheri-common/cheri-compressed-cap/test/fuzz-decompress.cpp
@@ -32,15 +32,16 @@
  * SUCH DAMAGE.
  */
 
-#include <cinttypes>
 #include "../cheri_compressed_cap.h"
-#include "sail_wrapper.h"
 #include "FuzzedDataProvider.h"
+#include "sail_wrapper.h"
+#include <cinttypes>
+#include <cstdio>
 
 static void dump_cap_fields(const cc128_cap_t& result) {
-    fprintf(stderr, "Permissions: 0x%" PRIx32 "\n", result.cr_perms); // TODO: decode perms
-    fprintf(stderr, "User Perms:  0x%" PRIx32 "\n", result.cr_uperms);
-    fprintf(stderr, "Base:        0x%016" PRIx64 "\n", result.cr_base);
+    fprintf(stderr, "Permissions: 0x%" PRIx32 "\n", result.permissions()); // TODO: decode perms
+    fprintf(stderr, "User Perms:  0x%" PRIx32 "\n", result.software_permissions());
+    fprintf(stderr, "Base:        0x%016" PRIx64 "\n", result.base());
     fprintf(stderr, "Offset:      0x%016" PRIx64 "\n", (uint64_t)result.offset());
     fprintf(stderr, "Cursor:      0x%016" PRIx64 "\n", result.address());
     fprintf(stderr, "Length:      0x%" PRIx64 "%016" PRIx64 " %s\n", (uint64_t)(result.length() >> 64),
@@ -48,8 +49,8 @@ static void dump_cap_fields(const cc128_cap_t& result) {
     cc128_length_t top_full = result.top();
     fprintf(stderr, "Top:         0x%" PRIx64 "%016" PRIx64 " %s\n", (uint64_t)(top_full >> 64), (uint64_t)top_full,
         top_full > UINT64_MAX ? " (greater than UINT64_MAX)" : "");
-    fprintf(stderr, "Sealed:      %d\n", (int)cc128_is_cap_sealed(&result));
-    fprintf(stderr, "OType:       0x%" PRIx32 "\n", result.cr_otype);
+    fprintf(stderr, "Sealed:      %d\n", (int)result.is_sealed());
+    fprintf(stderr, "OType:       0x%" PRIx32 "\n", result.type());
     fprintf(stderr, "\n");
 }
 

--- a/target/cheri-common/cheri-compressed-cap/test/random_inputs_test.cpp
+++ b/target/cheri-common/cheri-compressed-cap/test/random_inputs_test.cpp
@@ -1,7 +1,6 @@
 #include "../cheri_compressed_cap.h"
 #include <cinttypes>
 #include <cstdint>
-#include <cstdlib>
 #include <cstring>
 
 #define CATCH_CONFIG_MAIN // This tells Catch to provide a main() - only do this in one cpp file
@@ -49,13 +48,13 @@ static bool check_fields_match(const typename Handler::cap_t& result, const test
     CHECK_AND_SAVE_SUCCESS(sail_result._cr_cursor == result._cr_cursor);
     CHECK_AND_SAVE_SUCCESS(sail_result._cr_top == result._cr_top);
     CHECK_AND_SAVE_SUCCESS(sail_result.cr_base == result.cr_base);
-    CHECK_AND_SAVE_SUCCESS(sail_result.cached_pesbt == result.cached_pesbt);
-    CHECK_AND_SAVE_SUCCESS(sail_result.cr_flags == result.cr_flags);
-    CHECK_AND_SAVE_SUCCESS(sail_result.cr_otype == result.cr_otype);
-    CHECK_AND_SAVE_SUCCESS(sail_result.cr_perms == result.cr_perms);
-    CHECK_AND_SAVE_SUCCESS(sail_result.cr_reserved == result.cr_reserved);
+    CHECK_AND_SAVE_SUCCESS(sail_result.cr_pesbt == result.cr_pesbt);
+    CHECK_AND_SAVE_SUCCESS(sail_result.flags() == result.flags());
+    CHECK_AND_SAVE_SUCCESS(sail_result.type() == result.type());
+    CHECK_AND_SAVE_SUCCESS(sail_result.permissions() == result.permissions());
+    CHECK_AND_SAVE_SUCCESS(sail_result.reserved_bits() == result.reserved_bits());
     CHECK_AND_SAVE_SUCCESS(sail_result.cr_tag == result.cr_tag);
-    CHECK_AND_SAVE_SUCCESS(sail_result.cr_uperms == result.cr_uperms);
+    CHECK_AND_SAVE_SUCCESS(sail_result.software_permissions() == result.software_permissions());
 
     // Since we are parsing arbitrary bit patterns, the length can be negative.
     // For the CRRL/CRAM check we only look at the low 64 bits of length.

--- a/target/cheri-common/cheri-compressed-cap/test/setbounds_test.cpp
+++ b/target/cheri-common/cheri-compressed-cap/test/setbounds_test.cpp
@@ -63,15 +63,15 @@ static typename Handler::cap_t do_csetbounds(const typename Handler::cap_t& init
     CHECK(sail_exact == exact);
     check_csetbounds_invariants<Handler>(initial_cap, with_bounds, exact, requested_base, requested_top);
 
-    // Check that the cached_pesbt is updated correctly and matches sail
-    CHECK(with_bounds.cached_pesbt == Handler::compress_raw(&with_bounds));
-    CHECK(with_bounds.cached_pesbt == Handler::sail_compress_raw(&with_bounds));
+    // Check that the cr_pesbt is updated correctly and matches sail
+    CHECK(with_bounds.cr_pesbt == Handler::compress_raw(&with_bounds));
+    CHECK(with_bounds.cr_pesbt == Handler::sail_compress_raw(&with_bounds));
     // Re-create the bounded capability and assert that the current pesbt values matches that one.
     auto new_cap = Handler::make_max_perms_cap(with_bounds.base(), with_bounds.address(), with_bounds.top());
     CHECK(new_cap == with_bounds);
-    CHECK(new_cap.cached_pesbt == with_bounds.cached_pesbt);
-    CHECK(new_cap.cached_pesbt == Handler::compress_raw(&with_bounds));
-    CHECK(new_cap.cached_pesbt == Handler::sail_compress_raw(&with_bounds));
+    CHECK(new_cap.cr_pesbt == with_bounds.cr_pesbt);
+    CHECK(new_cap.cr_pesbt == Handler::compress_raw(&with_bounds));
+    CHECK(new_cap.cr_pesbt == Handler::sail_compress_raw(&with_bounds));
 
     if (was_exact)
         *was_exact = exact;

--- a/target/cheri-common/cheri-compressed-cap/test/test_util.h
+++ b/target/cheri-common/cheri-compressed-cap/test/test_util.h
@@ -1,3 +1,4 @@
+#include <cinttypes>
 #include <iostream>
 #include <ostream>
 #include <string>
@@ -43,12 +44,15 @@ std::ostream& operator<<(std::ostream& os, const cc128_cap_t& value) {
              "\tOffset:      0x%016" PRIx64 "\n"
              "\tLength:      0x%" PRIx64 "%016" PRIx64 " %s\n"
              "\tTop:         0x%" PRIx64 "%016" PRIx64 " %s\n"
+             "\tFlags:       %d\n"
+             "\tReserved:    %d\n"
              "\tSealed:      %d\n"
              "\tOType:       0x%" PRIx32 "%s\n",
-             value.cr_perms, value.cr_uperms, value.cr_base, (uint64_t)value.offset(), (uint64_t)(value.length() >> 64),
-             (uint64_t)value.length(), value.length() > UINT64_MAX ? " (greater than UINT64_MAX)" : "",
-             (uint64_t)(top_full >> 64), (uint64_t)top_full, top_full > UINT64_MAX ? " (greater than UINT64_MAX)" : "",
-             (int)(value.is_sealed()), value.cr_otype, otype_suffix(value.cr_otype));
+             value.permissions(), value.software_permissions(), value.base(), (uint64_t)value.offset(),
+             (uint64_t)(value.length() >> 64), (uint64_t)value.length(),
+             value.length() > UINT64_MAX ? " (greater than UINT64_MAX)" : "", (uint64_t)(top_full >> 64),
+             (uint64_t)top_full, top_full > UINT64_MAX ? " (greater than UINT64_MAX)" : "", (int)value.flags(),
+             (int)value.reserved_bits(), (int)(value.is_sealed()), value.type(), otype_suffix(value.type()));
     os << "{\n" << buffer << "}";
     return os;
 }
@@ -62,12 +66,14 @@ std::ostream& operator<<(std::ostream& os, const cc64_cap_t& value) {
              "\tOffset:      0x%08" PRIx32 "\n"
              "\tLength:      0x%08" PRIx64 " %s\n"
              "\tTop:         0x%08" PRIx64 " %s\n"
+             "\tFlags:       %d\n"
+             "\tReserved:    %d\n"
              "\tSealed:      %d\n"
              "\tOType:       0x%" PRIx32 "%s\n",
-             value.cr_perms, value.cr_uperms, value.base(), (uint32_t)value.offset(), (uint64_t)value.length(),
-             value.length() > UINT32_MAX ? " (greater than UINT32_MAX)" : "", (uint64_t)value.top(),
-             value.top() > UINT32_MAX ? " (greater than UINT32_MAX)" : "", (int)(value.is_sealed()), value.cr_otype,
-             otype_suffix(value.cr_otype));
+             value.permissions(), value.software_permissions(), value.base(), (uint32_t)value.offset(),
+             (uint64_t)value.length(), value.length() > UINT32_MAX ? " (greater than UINT32_MAX)" : "",
+             (uint64_t)value.top(), value.top() > UINT32_MAX ? " (greater than UINT32_MAX)" : "", (int)value.flags(),
+             (int)value.reserved_bits(), (int)(value.is_sealed()), value.type(), otype_suffix(value.type()));
     os << "{\n" << buffer << "}";
     return os;
 }
@@ -94,8 +100,8 @@ template <typename T> static inline bool check(T expected, T actual, const std::
 template <class T, std::size_t N> constexpr inline size_t array_lengthof(T (&)[N]) { return N; }
 
 template <class Cap> static void dump_cap_fields(const Cap& result) {
-    fprintf(stderr, "Permissions: 0x%" PRIx32 "\n", result.cr_perms); // TODO: decode perms
-    fprintf(stderr, "User Perms:  0x%" PRIx32 "\n", result.cr_uperms);
+    fprintf(stderr, "Permissions: 0x%" PRIx32 "\n", result.permissions()); // TODO: decode perms
+    fprintf(stderr, "User Perms:  0x%" PRIx32 "\n", result.software_permissions());
     fprintf(stderr, "Base:        0x%016" PRIx64 "\n", (uint64_t)result.base());
     fprintf(stderr, "Offset:      0x%016" PRIx64 "\n", (uint64_t)result.offset());
     fprintf(stderr, "Cursor:      0x%016" PRIx64 "\n", (uint64_t)result.address());
@@ -105,6 +111,8 @@ template <class Cap> static void dump_cap_fields(const Cap& result) {
     cc128_length_t top_full = result.top();
     fprintf(stderr, "Top:         0x%" PRIx64 "%016" PRIx64 " %s\n", (uint64_t)(top_full >> 64), (uint64_t)top_full,
             top_full > UINT64_MAX ? " (greater than UINT64_MAX)" : "");
+    fprintf(stderr, "Flags:       %d\n", (int)result.flags());
+    fprintf(stderr, "Reserved:    %d\n", (int)result.reserved_bits());
     fprintf(stderr, "Sealed:      %d\n", (int)result.is_sealed());
     fprintf(stderr, "OType:       0x%" PRIx32 "%s\n", result.type(), otype_suffix(result.type()));
     fprintf(stderr, "\n");

--- a/target/cheri-common/cheri-lazy-capregs-types.h
+++ b/target/cheri-common/cheri-lazy-capregs-types.h
@@ -69,13 +69,13 @@ typedef enum CapRegState {
 
 // Cap registers should be padded so they are easier to move.
 #if TARGET_LONG_BITS == 32
-_Static_assert(sizeof(cap_register_t) == 40, "");
+_Static_assert(sizeof(cap_register_t) == 24, "");
 #else
-_Static_assert(sizeof(cap_register_t) == 64, "");
+_Static_assert(sizeof(cap_register_t) == 48, "");
 #endif
 // pesbt should come directly before reg._cr_cursor, so that the two can be
 // moved with a single 128bit vector op.
-_Static_assert((offsetof(cap_register_t, cached_pesbt) -
+_Static_assert((offsetof(cap_register_t, cr_pesbt) -
                 offsetof(cap_register_t, _cr_cursor)) == sizeof(target_ulong),
                "");
 

--- a/target/riscv/translate.c
+++ b/target/riscv/translate.c
@@ -1085,7 +1085,7 @@ void riscv_translate_init(void)
             riscv_int_regnames[i]);
         _cpu_pesbt_do_not_access_directly[i] = tcg_global_mem_new(
             cpu_env,
-            offsetof(CPURISCVState, gpcapregs.decompressed[i].cached_pesbt),
+            offsetof(CPURISCVState, gpcapregs.decompressed[i].cr_pesbt),
             cheri_gp_regnames[i]);
     }
 #endif


### PR DESCRIPTION
Profiling showed that we were spending unncessary amounts of time
unpacking these fields. This speeds up a QEMU purecap kernel boot by
about 5 seconds:
```
hyperfine -L qemu 'qemu-system-riscv64cheri.e2d8499d9a,qemu-system-riscv64cheri' '/home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd /local/scratch/alr48/cheri/output/sdk/bin/{qemu} --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest' -m 5
Benchmark #1: /home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.e2d8499d9a --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest
  Time (mean ± σ):     215.379 s ±  1.550 s    [User: 203.415 s, System: 2.209 s]
  Range (min … max):   212.726 s … 216.815 s    5 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark #2: /home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest
  Time (mean ± σ):     210.971 s ±  1.600 s    [User: 199.158 s, System: 2.056 s]
  Range (min … max):   208.997 s … 212.825 s    5 runs

Summary
  '/home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest' ran
    1.02 ± 0.01 times faster than '/home/alr48/devel/cheribuild/test-scripts/run_cheribsd_tests.py --ssh-key /home/alr48/.ssh/insecure_id_ed25519.pub --architecture riscv64-purecap --kernel /local/scratch/alr48/cheri/output/rootfs-riscv64-purecap/boot/kernel.CHERI-PURECAP-QEMU/kernel --qemu-cmd /local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.e2d8499d9a --disk-image /local/scratch/alr48/cheri/output/cheribsd-riscv64-purecap.img --no-run-cheribsdtest'
```