### PR TITLE
Fix Morello capability store faults

### DIFF
--- a/target/arm/helper.c
+++ b/target/arm/helper.c
@@ -12726,8 +12726,10 @@ static bool get_phys_addr_lpae(CPUARMState *env, uint64_t address,
 
     // Cap stores can fault here as only tagged stores specify
     // MMU_DATA_CAP_STORE
-    if (!cdbm && !sc) {
-        *prot |= PAGE_SC_TRAP;
+    // Software capability dirty tracking means we fault on !sc
+    if (!sc) {
+        if (!cdbm)
+            *prot |= PAGE_SC_TRAP;
         if (access_type == MMU_DATA_CAP_STORE) {
             access_type = base_access_type;
             goto do_fault;


### PR DESCRIPTION
Previous logic had us only faulting when CDBM and SC are both unset, but for software manged capability dirty tracking we need to fault any time SC isn't set.