### PR TITLE
Avoid unneccessary probe_write/probe_read calls

### DIFF
--- a/target/cheri-common/cheri_tagmem.c
+++ b/target/cheri-common/cheri_tagmem.c
@@ -553,10 +553,13 @@ void cheri_tag_set(CPUArchState *env, target_ulong vaddr, int reg,
 }
 
 bool cheri_tag_get(CPUArchState *env, target_ulong vaddr, int reg,
-                   hwaddr *ret_paddr, int *prot, uintptr_t pc, int mmu_idx)
+                   hwaddr *ret_paddr, int *prot, uintptr_t pc, int mmu_idx,
+                   void *host_addr)
 {
 
-    void *host_addr = probe_read(env, vaddr, 1, mmu_idx, pc);
+    if (host_addr == NULL) {
+        host_addr = probe_read(env, vaddr, 1, mmu_idx, pc);
+    }
     handle_paddr_return(read);
 
     uintptr_t tagmem_flags;

--- a/target/cheri-common/cheri_tagmem.h
+++ b/target/cheri-common/cheri_tagmem.h
@@ -53,9 +53,10 @@ void cheri_tag_invalidate(CPUArchState *env, target_ulong vaddr, int32_t size,
  * Like cheri_tag_invalidate, but the address must be aligned and it will only
  * invalidate a single tag (i.e. no unaligned accesses). A bit faster since it
  * can avoid some branches.
+ * @return the host address as returned by probe_write().
  */
-void cheri_tag_invalidate_aligned(CPUArchState *env, target_ulong vaddr,
-                                  uintptr_t pc, int mmu_idx);
+void *cheri_tag_invalidate_aligned(CPUArchState *env, target_ulong vaddr,
+                                   uintptr_t pc, int mmu_idx);
 /**
  * If probe_read() has already been called, the result can be passed as the
  * @p host_addr argument to avoid another (expensive) probe_read() call.
@@ -72,8 +73,12 @@ int cheri_tag_get_many(CPUArchState *env, target_ulong vaddr, int reg,
 void cheri_tag_set_many(CPUArchState *env, uint32_t tags, target_ulong vaddr,
                         int reg, hwaddr *ret_paddr, uintptr_t pc);
 
-void cheri_tag_set(CPUArchState *env, target_ulong vaddr, int reg,
-                   hwaddr *ret_paddr, uintptr_t pc, int mmu_idx);
+/**
+ * Update a tag for virtual address @vaddr.
+ * @return the host address as returned by probe_cap_write()
+ */
+void *cheri_tag_set(CPUArchState *env, target_ulong vaddr, int reg,
+                    hwaddr *ret_paddr, uintptr_t pc, int mmu_idx);
 
 void *cheri_tagmem_for_addr(CPUArchState *env, target_ulong vaddr,
                             RAMBlock *ram, ram_addr_t ram_offset, size_t size,

--- a/target/cheri-common/cheri_tagmem.h
+++ b/target/cheri-common/cheri_tagmem.h
@@ -56,8 +56,13 @@ void cheri_tag_invalidate(CPUArchState *env, target_ulong vaddr, int32_t size,
  */
 void cheri_tag_invalidate_aligned(CPUArchState *env, target_ulong vaddr,
                                   uintptr_t pc, int mmu_idx);
+/**
+ * If probe_read() has already been called, the result can be passed as the
+ * @p host_addr argument to avoid another (expensive) probe_read() call.
+ */
 bool cheri_tag_get(CPUArchState *env, target_ulong vaddr, int reg,
-                   hwaddr *ret_paddr, int *prot, uintptr_t pc, int mmu_idx);
+                   hwaddr *ret_paddr, int *prot, uintptr_t pc, int mmu_idx,
+                   void *host_addr);
 /*
  * Get/set many currently don't have an mmu_idx because no targets currently
  * require it.

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -1373,14 +1373,13 @@ void store_cap_to_memory_mmu_index(CPUArchState *env, uint32_t cs,
      */
 
     env->statcounters_cap_write++;
+    void *host = NULL;
     if (tag) {
         env->statcounters_cap_write_tagged++;
-        cheri_tag_set(env, vaddr, cs, NULL, retpc, mmu_idx);
+        host = cheri_tag_set(env, vaddr, cs, NULL, retpc, mmu_idx);
     } else {
-        cheri_tag_invalidate_aligned(env, vaddr, retpc, mmu_idx);
+        host = cheri_tag_invalidate_aligned(env, vaddr, retpc, mmu_idx);
     }
-    /* No TLB fault possible, should be safe to get a host pointer now */
-    void *host = probe_write(env, vaddr, CHERI_CAP_SIZE, mmu_idx, retpc);
     // When writing back pesbt we have to XOR with the NULL mask to ensure that
     // NULL capabilities have an all-zeroes representation.
     if (likely(host)) {

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -1276,7 +1276,8 @@ bool load_cap_from_memory_raw_tag_mmu_idx(
         *cursor = cpu_ld_cap_word_ra(env, vaddr + CHERI_MEM_OFFSET_CURSOR, retpc);
     }
     int prot;
-    bool tag = cheri_tag_get(env, vaddr, cb, physaddr, &prot, retpc, mmu_idx);
+    bool tag =
+        cheri_tag_get(env, vaddr, cb, physaddr, &prot, retpc, mmu_idx, host);
     if (raw_tag) {
         *raw_tag = tag;
     }


### PR DESCRIPTION
This reduces the /sbin/startup-benchmark.sh cycles from 27,831,470,600 to 26,884,430,967 (about 3% faster).

Baseline:
```
 Performance counter stats for '/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri.dev-post-morello -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -kernel /local/scratch/alr48/cheri/output/kernel-riscv64-purecap.CHERI-PURECAP-QEMU-MFS-ROOT -append init_path=/sbin/startup-benchmark.sh -device virtio-rng-pci' (5 runs):

       8429.485885      task-clock (msec)         #    0.911 CPUs utilized            ( +-  0.35% )
             2,508      context-switches          #    0.298 K/sec                    ( +-  0.61% )
                 1      cpu-migrations            #    0.000 K/sec                    ( +- 66.67% )
            12,867      page-faults               #    0.002 M/sec                    ( +-  0.79% )
    27,831,470,600      cycles                    #    3.302 GHz                      ( +-  0.08% )
    77,801,651,546      instructions              #    2.80  insn per cycle           ( +-  0.01% )
    11,223,140,290      branches                  # 1331.415 M/sec                    ( +-  0.01% )
       164,672,766      branch-misses             #    1.47% of all branches          ( +-  0.08% )

       9.256983251 seconds time elapsed                                          ( +-  0.23% )
```
Avoiding probe_read:
```
 Performance counter stats for '/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -kernel /local/scratch/alr48/cheri/output/kernel-riscv64-purecap.CHERI-PURECAP-QEMU-MFS-ROOT -append init_path=/sbin/startup-benchmark.sh -device virtio-rng-pci' (5 runs):

       8177.658418      task-clock (msec)         #    0.936 CPUs utilized            ( +-  0.71% )
             2,398      context-switches          #    0.293 K/sec                    ( +-  1.64% )
                 0      cpu-migrations            #    0.000 K/sec                    ( +-100.00% )
            12,858      page-faults               #    0.002 M/sec                    ( +-  0.59% )
    27,261,165,519      cycles                    #    3.334 GHz                      ( +-  0.17% )
    75,402,569,943      instructions              #    2.77  insn per cycle           ( +-  0.16% )
    11,183,417,524      branches                  # 1367.557 M/sec                    ( +-  0.15% )
       162,719,113      branch-misses             #    1.46% of all branches          ( +-  0.20% )

       8.738376962 seconds time elapsed                                          ( +-  3.03% )                        ( +-  0.23% )
```

Avoiding probe_read+probe_write:
```
 Performance counter stats for '/local/scratch/alr48/cheri/output/sdk/bin/qemu-system-riscv64cheri -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -kernel /local/scratch/alr48/cheri/output/kernel-riscv64-purecap.CHERI-PURECAP-QEMU-MFS-ROOT -append init_path=/sbin/startup-benchmark.sh -device virtio-rng-pci' (5 runs):

       8104.302443      task-clock (msec)         #    0.929 CPUs utilized            ( +-  0.96% )
             2,354      context-switches          #    0.290 K/sec                    ( +-  1.97% )
                 3      cpu-migrations            #    0.000 K/sec                    ( +- 14.91% )
            12,859      page-faults               #    0.002 M/sec                    ( +-  0.49% )
    26,884,430,967      cycles                    #    3.317 GHz                      ( +-  0.27% )
    73,508,873,268      instructions              #    2.73  insn per cycle           ( +-  0.17% )
    10,967,898,668      branches                  # 1353.343 M/sec                    ( +-  0.16% )
       163,992,148      branch-misses             #    1.50% of all branches          ( +-  0.22% )

       8.725517766 seconds time elapsed                                          ( +-  3.14% )                      ( +-  3.03% )
```