### PR TITLE
CHERI-RISC-V: slightly rearrange SLTI HINT decoder

### DIFF
--- a/target/riscv/insn_trans/trans_rvi.c.inc
+++ b/target/riscv/insn_trans/trans_rvi.c.inc
@@ -248,52 +248,62 @@ static void gen_sltu(TCGv ret, TCGv s1, TCGv s2)
 
 static bool trans_slti(DisasContext *ctx, arg_slti *a)
 {
-#ifdef CONFIG_TCG_LOG_INSTR
-    /*
-     * If instruction tracing is enabled, we use slti zero, zero, <magic>
-     * to perform magic-nop tracing control operations.
-     * These will trigger a flush of the TCG buffer, so prepare to resume
-     * from next instruction.
-     */
     if (unlikely(a->rd == 0)) {
-        TCGv tpc = tcg_const_tl(ctx->base.pc_next);
-        TCGv_i32 ttmp;
+        switch (a->rs1) {
+        case 0x0: /* x0: imm specifies particular hint */
+            /* imm == 0 reserved */
+            /* imm in [1, 0x2f] reserved for tracing framework */
+            if ((a->imm > 0) && (a->imm <= 0x2f)) {
+#ifdef CONFIG_TCG_LOG_INSTR
+                /*
+                 * If instruction tracing is enabled, we use slti zero, zero,
+                 * <magic> to perform magic-nop tracing control operations.
+                 * These will trigger a flush of the TCG buffer, so prepare to
+                 * resume from next instruction.
+                 */
+                TCGv tpc = tcg_const_tl(ctx->base.pc_next);
+                TCGv_i32 ttmp;
+                switch (a->imm) {
+                case 0x01: case 0x02:
+                    ttmp = tcg_const_i32(a->imm == 0x01);
+                    gen_helper_qemu_log_instr_buffered_mode(cpu_env, ttmp);
+                    tcg_temp_free_i32(ttmp);
+                    break;
+                case 0x03:
+                    gen_helper_qemu_log_instr_buffer_flush(cpu_env);
+                    break;
+                case 0x1b:
+                    gen_helper_qemu_log_instr_start(cpu_env, tpc);
+                    ctx->base.is_jmp = DISAS_NORETURN;
+                    break;
+                case 0x1e:
+                    gen_helper_qemu_log_instr_stop(cpu_env, tpc);
+                    ctx->base.is_jmp = DISAS_NORETURN;
+                    break;
+                case 0x2b:
+                    gen_helper_qemu_log_instr_user_start(cpu_env, tpc);
+                    ctx->base.is_jmp = DISAS_NORETURN;
+                    break;
+                case 0x2e:
+                    gen_helper_qemu_log_instr_stop(cpu_env, tpc);
+                    ctx->base.is_jmp = DISAS_NORETURN;
+                    break;
+                }
+                tcg_temp_free(tpc);
 
-        switch (a->imm) {
-        case 0x01: case 0x02:
-            ttmp = tcg_const_i32(a->imm == 0x01);
-            gen_helper_qemu_log_instr_buffered_mode(cpu_env, ttmp);
-            tcg_temp_free_i32(ttmp);
+                if (ctx->base.is_jmp != DISAS_NEXT) {
+                    gen_update_cpu_pc(ctx->pc_succ_insn);
+                    exit_tb(ctx);
+                    return true;
+                }
+#endif
+            }
+            /* imm in [ 0x30, 0xFFF ] are reserved for future CHERI expansion */
             break;
-        case 0x03:
-            gen_helper_qemu_log_instr_buffer_flush(cpu_env);
-            break;
-        case 0x1b:
-            gen_helper_qemu_log_instr_start(cpu_env, tpc);
-            ctx->base.is_jmp = DISAS_NORETURN;
-            break;
-        case 0x1e:
-            gen_helper_qemu_log_instr_stop(cpu_env, tpc);
-            ctx->base.is_jmp = DISAS_NORETURN;
-            break;
-        case 0x2b:
-            gen_helper_qemu_log_instr_user_start(cpu_env, tpc);
-            ctx->base.is_jmp = DISAS_NORETURN;
-            break;
-        case 0x2e:
-            gen_helper_qemu_log_instr_stop(cpu_env, tpc);
-            ctx->base.is_jmp = DISAS_NORETURN;
-            break;
-        }
-        tcg_temp_free(tpc);
 
-        if (ctx->base.is_jmp != DISAS_NEXT) {
-            gen_update_cpu_pc(ctx->pc_succ_insn);
-            exit_tb(ctx);
-            return true;
+        /* rs1 in [1, 31] is reserved for future CHERI expansion */
         }
     }
-#endif
     return gen_arith_imm_tl(ctx, a, &gen_slt);
 }
 


### PR DESCRIPTION
- Restructure the code under the assumption that there will be HINT consumers
  other than TCG_LOG_INSTR.

- Document the current and near-term allocations of the opcode space:

  - Move the TCG_LOG_INSTR tests to match rs1 == x0, which is the only form that
    we have emitted, but we were never ignoring rs1.

  - Reserve `SLTI x0, x31, 0xNNN` forms for software's introspective use until
    (and if) RISC-V upstream defines something for that use case.

XREF https://github.com/CTSRD-CHERI/cheri-architecture/pull/78