### PR TITLE
Move CapRegState into a new cap_register_t field 

### DIFF
--- a/target/arm/cheri-archspecific-early.h
+++ b/target/arm/cheri-archspecific-early.h
@@ -34,11 +34,14 @@
 
 static inline const cap_register_t *cheri_get_ddc(CPUARMState *env)
 {
+    cheri_debug_assert(env->DDC_current.cap.cr_extra ==
+                       CREG_FULLY_DECOMPRESSED);
     return &env->DDC_current.cap;
 }
 
 static inline const cap_register_t *_cheri_get_pcc_unchecked(CPUARMState *env)
 {
+    cheri_debug_assert(env->pc.cap.cr_extra == CREG_FULLY_DECOMPRESSED);
     return &env->pc.cap;
 }
 

--- a/target/arm/cheri-archspecific.h
+++ b/target/arm/cheri-archspecific.h
@@ -213,6 +213,7 @@ static inline void update_next_pcc_for_tcg(CPUARMState *env,
     unsigned int cur_el;
 
     env->pc.cap = *target;
+    cheri_debug_assert(env->pc.cap.cr_extra == CREG_FULLY_DECOMPRESSED);
     env->pc.cap._cr_cursor &= ~1;
 
     if (executive_changed) {

--- a/target/arm/cheri-archspecific.h
+++ b/target/arm/cheri-archspecific.h
@@ -201,7 +201,7 @@ static inline void update_next_pcc_for_tcg(CPUARMState *env,
 
     // TODO: Reading BranchAddr in the arm ARM it looks like there is some
     // top byte sign extending not being respected here
-    uint32_t old_perms = cap_get_perms(&env->pc.cap);
+    uint32_t old_perms = cap_get_perms(cheri_get_recent_pcc(env));
     uint32_t new_perms = cap_get_perms(target);
 
     bool system_changed = ((old_perms ^ new_perms) & CAP_ACCESS_SYS_REGS) != 0;

--- a/target/arm/cheri_helper.c
+++ b/target/arm/cheri_helper.c
@@ -315,15 +315,8 @@ void helper_load_pair_and_branch_and_link(CPUArchState *env, uint32_t cn,
                          _host_return_address, &base, CHERI_CAP_SIZE,
                          raise_unaligned_load_exception);
 
-    uint64_t target_pesbt, target_cursor;
-    bool target_tag = load_cap_from_memory_raw(
-        env, &target_pesbt, &target_cursor, cn, &base, addr + CHERI_CAP_SIZE,
-        _host_return_address, NULL);
-
-    cap_register_t target;
-    target.cr_pesbt = target_pesbt;
-    CAP_cc(decompress_raw)(target_pesbt, target_cursor, target_tag, &target);
-
+    cap_register_t target = load_and_decompress_cap_from_memory_raw(
+        env, cn, &base, addr + CHERI_CAP_SIZE, _host_return_address, NULL);
     // We do this load SECOND as it has a register-file side effect.
     load_cap_from_memory(env, ct, cn, &base, addr, _host_return_address, NULL);
 
@@ -352,15 +345,8 @@ void helper_load_and_branch_and_link(CPUArchState *env, uint32_t cn,
                          _host_return_address, &base, CHERI_CAP_SIZE,
                          raise_unaligned_load_exception);
 
-    uint64_t target_pesbt, target_cursor;
-    bool target_tag =
-        load_cap_from_memory_raw(env, &target_pesbt, &target_cursor, cn, &base,
-                                 addr, _host_return_address, NULL);
-
-    cap_register_t target;
-    target.cr_pesbt = target_pesbt;
-    CAP_cc(decompress_raw)(target_pesbt, target_cursor, target_tag, &target);
-
+    cap_register_t target = load_and_decompress_cap_from_memory_raw(
+        env, cn, &base, addr, _host_return_address, NULL);
     cheri_jump_and_link(env, &target, cap_get_cursor(&target), link, link_pc,
                         flags);
 }

--- a/target/arm/cpu.c
+++ b/target/arm/cpu.c
@@ -251,7 +251,7 @@ static void arm_cpu_reset(DeviceState *dev)
 
 #ifdef TARGET_CHERI
         reset_capregs(env);
-        env->pc.cap = CAP_cc(make_max_perms_cap)(0, cpu->rvbar, CAP_MAX_TOP);
+        set_max_perms_capability(&env->pc.cap, cpu->rvbar);
 #else
         env->pc = cpu->rvbar;
 #endif

--- a/target/arm/cpu.c
+++ b/target/arm/cpu.c
@@ -159,6 +159,7 @@ static void cp_reg_reset(gpointer key, gpointer value, gpointer opaque)
         } else {
             null_capability(&CPREG_FIELDCAP(&cpu->env, ri));
         }
+        return;
     }
 #endif
 
@@ -170,9 +171,7 @@ static void cp_reg_reset(gpointer key, gpointer value, gpointer opaque)
     if (!ri->fieldoffset) {
         return;
     }
-    if (cpreg_field_is_cap(ri)) {
-        /* Initialized above. */
-    } else if (cpreg_field_is_64bit(ri)) {
+    if (cpreg_field_is_64bit(ri)) {
         CPREG_FIELD64(&cpu->env, ri) = ri->resetvalue;
     } else {
         CPREG_FIELD32(&cpu->env, ri) = ri->resetvalue;

--- a/target/arm/cpu.h
+++ b/target/arm/cpu.h
@@ -4452,41 +4452,50 @@ static inline uint32_t arm_rebuild_chflags_el(CPUARMState *env, int el)
     _Static_assert(TBFLAG_CHERI_SIZE + TB_FLAG_CHERI_SPARE_INDEX_START + 1 < 32,
                    "");
     uint32_t chflags = (env->CCTLR_el[el] >> CCTLR_DEFINED_START);
-    if (env->pstate & PSTATE_C64)
+    if (env->pstate & PSTATE_C64) {
         chflags = FIELD_DP32(chflags, TBFLAG_CHERI, PSTATE_C64, 1);
-    if (cap_has_perms(&env->pc.cap, CAP_PERM_EXECUTIVE))
+    }
+    if (cap_has_perms(_cheri_get_pcc_unchecked(env), CAP_PERM_EXECUTIVE)) {
         chflags = FIELD_DP32(chflags, TBFLAG_CHERI, EXECUTIVE, 1);
-    if (cap_has_perms(&env->pc.cap, CAP_ACCESS_SYS_REGS))
+    }
+    if (cap_has_perms(_cheri_get_pcc_unchecked(env), CAP_ACCESS_SYS_REGS)) {
         chflags = FIELD_DP32(chflags, TBFLAG_CHERI, SYSTEM, 1);
-    if (arm_is_tag_setting_disabled(env, el))
+    }
+    if (arm_is_tag_setting_disabled(env, el)) {
         chflags = FIELD_DP32(chflags, TBFLAG_CHERI, SETTAG, 1);
-    if (get_cap_enabled_target_exception_level_el(env, el) == -1)
+    }
+    if (get_cap_enabled_target_exception_level_el(env, el) == -1) {
         chflags = FIELD_DP32(chflags, TBFLAG_CHERI, CAP_ENABLED, 1);
+    }
     uint64_t sctlr = arm_sctlr(env, el);
-    if (sctlr & SCTLR_A)
+    if (sctlr & SCTLR_A) {
         chflags = FIELD_DP32(chflags, TBFLAG_CHERI, SCTLRA, 1);
-    if ((el == 0) ? (sctlr & SCTLR_SA0) : (sctlr & SCTLR_SA))
+    }
+    if ((el == 0) ? (sctlr & SCTLR_SA0) : (sctlr & SCTLR_SA)) {
         chflags = FIELD_DP32(chflags, TBFLAG_CHERI, SCTLRSA, 1);
+    }
 
     uint32_t chflags_changed = env->chflags ^ chflags;
     env->chflags = chflags;
 
-    if (FIELD_EX32(chflags_changed, TBFLAG_CHERI, PSTATE_C64))
+    if (FIELD_EX32(chflags_changed, TBFLAG_CHERI, PSTATE_C64)) {
         qemu_maybe_log_instr_extra(env, "New C64 state: %s\n",
                                    FIELD_EX32(chflags, TBFLAG_CHERI, PSTATE_C64)
                                        ? "Enabled"
                                        : "Disabled");
-    if (FIELD_EX32(chflags_changed, TBFLAG_CHERI, EXECUTIVE))
+    }
+    if (FIELD_EX32(chflags_changed, TBFLAG_CHERI, EXECUTIVE)) {
         qemu_maybe_log_instr_extra(env, "New executive state: %s\n",
                                    FIELD_EX32(chflags, TBFLAG_CHERI, EXECUTIVE)
                                        ? "Enabled"
                                        : "Disabled");
-    if (FIELD_EX32(chflags_changed, TBFLAG_CHERI, CAP_ENABLED))
+    }
+    if (FIELD_EX32(chflags_changed, TBFLAG_CHERI, CAP_ENABLED)) {
         qemu_maybe_log_instr_extra(
             env, "New cap enabled state: %s\n",
             FIELD_EX32(chflags, TBFLAG_CHERI, CAP_ENABLED) ? "Enabled"
                                                            : "Disabled");
-
+    }
     return chflags;
 }
 

--- a/target/arm/helper-a64.c
+++ b/target/arm/helper-a64.c
@@ -38,7 +38,7 @@
 #include "exec/log_instr.h"
 
 #ifdef TARGET_CHERI
-#include "cheri-archspecific.h"
+#include "cheri-helper-utils.h"
 #include "cheri_tagmem.h"
 #endif
 
@@ -1033,7 +1033,7 @@ void HELPER(exception_return)(CPUARMState *env, uint64_t new_pc)
 
 #ifdef TARGET_CHERI
         bool cap_return = is_access_to_capabilities_enabled_at_el(env, cur_el);
-        bool no_system = !cap_has_perms(&env->pc.cap, CAP_ACCESS_SYS_REGS);
+        bool no_system = !cheri_have_access_sysregs(env);
 
         if (!cap_return ||
             !is_access_to_capabilities_enabled_at_el(env, new_el))

--- a/target/arm/helper.c
+++ b/target/arm/helper.c
@@ -165,6 +165,13 @@ static void raw_write_cap(CPUARMState *env, const ARMCPRegInfo *ri,
     CPREG_FIELDCAP(env, ri) = *cap;
     CPREG_FIELDCAP(env, ri)._cr_cursor = value;
 }
+
+cap_register_t read_raw_cp_reg_cap(CPUARMState *env, const ARMCPRegInfo *ri)
+{
+    cap_register_t result;
+    raw_read_cap(env, ri, &result);
+    return result;
+}
 #endif
 
 static uint64_t raw_read(CPUARMState *env, const ARMCPRegInfo *ri)
@@ -210,11 +217,8 @@ uint64_t read_raw_cp_reg(CPUARMState *env, const ARMCPRegInfo *ri)
     /* Raw read of a coprocessor register (as needed for migration, etc). */
     // This will need a cap version to migrate CHERI CPUs
     if (ri->type & ARM_CP_CONST) {
-#ifdef TARGET_CHERI
-        if (ri->type & ARM_CP_CAP) {
-            return ri->capresetvalue._cr_cursor;
-        }
-#endif
+        assert(!cpreg_field_is_cap(ri) &&
+               "There are no constant cap cpregs (yet?).");
         return ri->resetvalue;
     } else if (ri->raw_readfn) {
         return ri->raw_readfn(env, ri);
@@ -8498,8 +8502,6 @@ void register_cp_regs_for_features(ARMCPU *cpu)
     // LETODO: Stuff to do with CPACR_ELX.CEN / EN for stopping DDC access, also
     // HCR controls a lot of these LETODO: Also have to pay attention to
     // restricted for RDDC and RSP.
-    cap_register_t null_cap;
-    null_capability(&null_cap);
     cap_register_t max_cap;
     set_max_perms_capability(&max_cap, 0);
     /* clang-format off */
@@ -8510,32 +8512,31 @@ void register_cp_regs_for_features(ARMCPU *cpu)
           .opc0 = 3, .opc1 = 3, .crn = 4, .crm = 1, .opc2 = 1,
           .access = PL0_RW | PL_NO_SYSREG, .type = ARM_CP_CAP_ONLY,
           .fieldoffset = offsetof(CPUARMState, DDC_current),
-          .capresetvalue = max_cap },
+          CAPRESETVALUE(max_cap) },
         { .name = "DDC_EL0", .state = ARM_CP_STATE_AA64,
           .opc0 = 3, .opc1 = 0, .crn = 4, .crm = 1, .opc2 = 1,
           .access = PL1_RW | PL_NO_SYSREG, .type = ARM_CP_CAP_ONLY,
           .fieldoffset = offsetof(CPUARMState, DDCs[0]),
-          .capresetvalue = max_cap },
+          CAPRESETVALUE(max_cap) },
         { .name = "DDC_EL1", .state = ARM_CP_STATE_AA64,
           .opc0 = 3, .opc1 = 4, .crn = 4, .crm = 1, .opc2 = 1,
           .access = PL2_RW | PL_NO_SYSREG, .type = ARM_CP_CAP_ONLY,
           .fieldoffset = offsetof(CPUARMState, DDCs[1]),
-          .capresetvalue = max_cap },
+          CAPRESETVALUE(max_cap) },
         { .name = "DDC_EL2", .state = ARM_CP_STATE_AA64,
           .opc0 = 3, .opc1 = 6, .crn = 4, .crm = 1, .opc2 = 1,
           .access = PL3_RW | PL_NO_SYSREG, .type = ARM_CP_CAP_ONLY,
           .fieldoffset = offsetof(CPUARMState, DDCs[2]),
-          .capresetvalue = max_cap },
+          CAPRESETVALUE(max_cap) },
         { .name = "RDDC_EL0", .state = ARM_CP_STATE_AA64,
           .opc0 = 3, .opc1 = 3, .crn = 4, .crm = 3, .opc2 = 1,
           .access = PL0_RW | PL_NO_SYSREG, .type = ARM_CP_CAP_ONLY,
           .fieldoffset = offsetof(CPUARMState, DDCs[4]),
-          .capresetvalue = max_cap },
+          CAPRESETVALUE(max_cap) },
         { .name = "RSP_EL0", .state = ARM_CP_STATE_AA64,
           .opc0 = 3, .opc1 = 7, .crn = 4, .crm = 1, .opc2 = 3,
           .access = PL0_RW | PL_NO_SYSREG, .type = ARM_CP_CAP,
-          .fieldoffset = offsetof(CPUARMState, sp_el[4]),
-          .capresetvalue = null_cap },
+          .fieldoffset = offsetof(CPUARMState, sp_el[4]) },
         // TODO: bits in CPTR control access to these
         { .name = "CHCR_EL2", .state = ARM_CP_STATE_AA64,
           .opc0 = 3, .opc1 = 4, .crn = 1, .crm = 2, .opc2 = 3,
@@ -8571,8 +8572,7 @@ void register_cp_regs_for_features(ARMCPU *cpu)
         { .name = "CID_EL0", .state = ARM_CP_STATE_AA64,
           .opc0 = 3, .opc1 = 3, .crn = 13, .crm = 0, .opc2 = 7,
           .access = PL0_RW | PL_NO_SYSREG, .type = ARM_CP_CAP,
-          .fieldoffset = offsetof(CPUARMState, cid_el0),
-          .capresetvalue = null_cap },
+          .fieldoffset = offsetof(CPUARMState, cid_el0) },
         { .name = "TPIDRRO_EL0", .state = ARM_CP_STATE_AA64,
           .opc0 = 3, .opc1 = 3, .opc2 = 4, .crn = 13, .crm = 0,
           .access = PL0_RW | PL_IN_EXECUTIVE | PL_NO_SYSREG,

--- a/target/arm/helper.c
+++ b/target/arm/helper.c
@@ -8499,8 +8499,9 @@ void register_cp_regs_for_features(ARMCPU *cpu)
     // HCR controls a lot of these LETODO: Also have to pay attention to
     // restricted for RDDC and RSP.
     cap_register_t null_cap;
-    bzero(&null_cap, sizeof(null_cap));
-    cap_register_t max_cap = cc128_make_max_perms_cap(0, 0, CAP_MAX_TOP);
+    null_capability(&null_cap);
+    cap_register_t max_cap;
+    set_max_perms_capability(&max_cap, 0);
     /* clang-format off */
     ARMCPRegInfo cheri_regs[] = {
         // We swap the relevent DDC into this register, so it is always

--- a/target/arm/helper.c
+++ b/target/arm/helper.c
@@ -13640,8 +13640,9 @@ void aarch_cpu_get_tb_cpu_state(CPUARMState *env, target_ulong *pc,
         *pc = get_aarch_reg_as_x(&env->pc);
 
 #ifdef TARGET_CHERI
-        cheri_cpu_get_tb_cpu_state(&env->pc.cap, cheri_get_ddc(env), cs_base,
-                                   cs_top, cheri_flags);
+        cheri_cpu_get_tb_cpu_state(_cheri_get_pcc_unchecked(env),
+                                   cheri_get_ddc(env), cs_base, cs_top,
+                                   cheri_flags);
         *cheri_flags |= (env->chflags << TB_FLAG_CHERI_SPARE_INDEX_START);
 #else
         *cs_base = 0;

--- a/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap_common.h
+++ b/target/cheri-common/cheri-compressed-cap/cheri_compressed_cap_common.h
@@ -129,11 +129,12 @@ struct _cc_N(cap) {
     _cc_addr_t _cr_cursor;
     _cc_addr_t cr_pesbt;
 #endif
-    _cc_length_t _cr_top;  /* Capability top */
-    _cc_addr_t cr_base;    /* Capability base addr */
-    uint8_t cr_tag;      /* Tag */
+    _cc_length_t _cr_top;    /* Capability top */
+    _cc_addr_t cr_base;      /* Capability base addr */
+    uint8_t cr_tag;          /* Tag */
     uint8_t cr_bounds_valid; /* Set if bounds decode was given an invalid cap */
     uint8_t cr_exp;          /* Exponent */
+    uint8_t cr_extra;        /* Additional data stored by the caller */
 #ifdef __cplusplus
     inline _cc_addr_t base() const { return cr_base; }
     inline _cc_addr_t address() const { return _cr_cursor; }

--- a/target/cheri-common/cheri-helper-utils.h
+++ b/target/cheri-common/cheri-helper-utils.h
@@ -369,6 +369,10 @@ bool load_cap_from_memory_raw_tag_mmu_idx(
     CPUArchState *env, target_ulong *pesbt, target_ulong *cursor, uint32_t cb,
     const cap_register_t *source, target_ulong vaddr, target_ulong retpc,
     hwaddr *physaddr, bool *raw_tag, int mmu_idx);
+/* Useful for the load+branch capability helpers. */
+cap_register_t load_and_decompress_cap_from_memory_raw(
+    CPUArchState *env, uint32_t cb, const cap_register_t *source,
+    target_ulong vaddr, target_ulong retpc, hwaddr *physaddr);
 
 void cheri_jump_and_link(CPUArchState *env, const cap_register_t *target,
                          target_ulong addr, uint32_t link_reg,

--- a/target/cheri-common/cheri-lazy-capregs-types.h
+++ b/target/cheri-common/cheri-lazy-capregs-types.h
@@ -107,7 +107,6 @@ typedef struct GPCapRegs {
      * needed. These special extra registers are always in state decompressed.
      */
     aligned_cap_register_t decompressed[NUM_LAZY_CAP_REGS];
-    /* CapRegState */ uint8_t capreg_state[NUM_LAZY_CAP_REGS] QEMU_ALIGNED(64);
 } GPCapRegs;
 
 static inline cap_register_t *get_cap_in_gpregs(GPCapRegs *gpcrs, size_t index)

--- a/target/cheri-common/cheri_utils.h
+++ b/target/cheri-common/cheri_utils.h
@@ -308,6 +308,7 @@ static inline cap_register_t *null_capability(cap_register_t *cp)
     cheri_debug_assert(cap_is_representable(cp));
     cp->cr_bounds_valid = 1;
     cp->cr_exp = CAP_CC(NULL_EXP);
+    cp->cr_extra = CREG_FULLY_DECOMPRESSED;
     return cp;
 }
 
@@ -376,6 +377,7 @@ static inline void set_max_perms_capability(cap_register_t *crp,
                                             target_ulong cursor)
 {
     *crp = CAP_cc(make_max_perms_cap)(0, cursor, CAP_MAX_TOP);
+    crp->cr_extra = CREG_FULLY_DECOMPRESSED;
 }
 
 static inline QEMU_ALWAYS_INLINE bool

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -1345,6 +1345,7 @@ cap_register_t load_and_decompress_cap_from_memory_raw(
                                         retpc, physaddr);
     cap_register_t result;
     CAP_cc(decompress_raw)(pesbt, cursor, tag, &result);
+    result.cr_extra = CREG_FULLY_DECOMPRESSED;
     return result;
 }
 

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -1336,6 +1336,18 @@ bool load_cap_from_memory_raw(CPUArchState *env, target_ulong *pesbt,
                                         retpc, physaddr, NULL);
 }
 
+cap_register_t load_and_decompress_cap_from_memory_raw(
+    CPUArchState *env, uint32_t cb, const cap_register_t *source,
+    target_ulong vaddr, target_ulong retpc, hwaddr *physaddr)
+{
+    target_ulong pesbt, cursor;
+    bool tag = load_cap_from_memory_raw(env, &pesbt, &cursor, cb, source, vaddr,
+                                        retpc, physaddr);
+    cap_register_t result;
+    CAP_cc(decompress_raw)(pesbt, cursor, tag, &result);
+    return result;
+}
+
 void load_cap_from_memory(CPUArchState *env, uint32_t cd, uint32_t cb,
                           const cap_register_t *source, target_ulong vaddr,
                           target_ulong retpc, hwaddr *physaddr)

--- a/target/mips/cheri-archspecific-early.h
+++ b/target/mips/cheri-archspecific-early.h
@@ -96,11 +96,14 @@ typedef enum CheriCapExc {
 } CheriCapExcCause;
 
 static inline const cap_register_t *cheri_get_ddc(CPUMIPSState *env) {
+    cheri_debug_assert(env->active_tc.CHWR.DDC.cr_extra ==
+                       CREG_FULLY_DECOMPRESSED);
     return &env->active_tc.CHWR.DDC;
 }
 
 static inline const cap_register_t *_cheri_get_pcc_unchecked(CPUMIPSState *env)
 {
+    cheri_debug_assert(env->active_tc.PCC.cr_extra == CREG_FULLY_DECOMPRESSED);
     return &env->active_tc.PCC;
 }
 

--- a/target/riscv/cheri-archspecific-early.h
+++ b/target/riscv/cheri-archspecific-early.h
@@ -111,11 +111,13 @@ enum CheriSCR {
 #define CINVOKE_DATA_REGNUM 31
 
 static inline const cap_register_t *cheri_get_ddc(CPURISCVState *env) {
+    cheri_debug_assert(env->DDC.cr_extra == CREG_FULLY_DECOMPRESSED);
     return &env->DDC;
 }
 
 static inline const cap_register_t *_cheri_get_pcc_unchecked(CPURISCVState *env)
 {
+    cheri_debug_assert(env->PCC.cr_extra == CREG_FULLY_DECOMPRESSED);
     return &env->PCC;
 }
 


### PR DESCRIPTION
This allows us to simply copy cap_register_t values and not have to worry
about updating the external capreg_state array.
Longer-term it would be good to have cheri-compressed-cap transparently
handle the bounds decoded/raw bits states, but for now it is a lot easier
to add a cr_extra field to retain the existing meaning of the CREG_*
constants. This also means we don't have to adjust the Morello TCG code
that uses these constants.