### PR TITLE
Capability SYS instructions use zero not sp

### DIFF
--- a/target/arm/translate-cheri.inc.c
+++ b/target/arm/translate-cheri.inc.c
@@ -42,9 +42,6 @@
 
 #define ONES(X) ((1ULL << (X)) - 1)
 
-#define AS_ZERO(X) ((X) == 31 ? 32 : (X))
-#define STANDARD_ZERO(X) ((X) == 32 ? 31 : (X))
-
 #define TRANS_F(NAME) static bool trans_##NAME(DisasContext *ctx, arg_##NAME *a)
 
 typedef void(cheri_cap_cap_imm_helper)(TCGv_env, TCGv_i32, TCGv_i32, TCGv);


### PR DESCRIPTION
CHERI helpers were expecting a special 'zero' register number to be passed rather than the encoded register number. This was not being respected in MSR/MRS, which are the only places the zero register (rather than SP) can end up being bounds checked.