### PR TITLE
[Morello] Don't assert jump targets are representable

### DIFF
--- a/target/arm/cheri-archspecific-early.h
+++ b/target/arm/cheri-archspecific-early.h
@@ -32,6 +32,8 @@
 
 #include "cheri-archspecific-earlier.h"
 
+#define CHERI_CONTROLFLOW_CHECK_AT_TARGET 1
+
 static inline const cap_register_t *cheri_get_ddc(CPUARMState *env)
 {
     cheri_debug_assert(env->DDC_current.cap.cr_extra ==

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -418,7 +418,7 @@ void CHERI_HELPER_IMPL(cjalr(CPUArchState *env, uint32_t cd,
     const target_ulong cursor = cap_get_cursor(cbp);
     const target_ulong addr = cursor + (target_long)offset;
     /* Morello takes the exception at the target. */
-#if CHERI_CONTROLFLOW_CHECK_AT_TARGET
+#if !CHERI_CONTROLFLOW_CHECK_AT_TARGET
     GET_HOST_RETPC();
     if (!cbp->cr_tag) {
         raise_cheri_exception(env, CapEx_TagViolation, cb);

--- a/target/mips/cheri-archspecific-early.h
+++ b/target/mips/cheri-archspecific-early.h
@@ -55,6 +55,7 @@
 #define CHERI_EXC_REGNUM_PCC 0xff
 #define CHERI_REGNUM_IDC  26  /* Invoked Data Capability */
 #define CINVOKE_DATA_REGNUM CHERI_REGNUM_IDC
+#define CHERI_CONTROLFLOW_CHECK_AT_TARGET 0
 
 /*
  * QEMU currently tells the kernel that there are no caches installed

--- a/target/riscv/cheri-archspecific-early.h
+++ b/target/riscv/cheri-archspecific-early.h
@@ -108,6 +108,7 @@ enum CheriSCR {
 
 #define CHERI_EXC_REGNUM_PCC (32 + CheriSCR_PCC)
 #define CHERI_EXC_REGNUM_DDC (32 + CheriSCR_DDC)
+#define CHERI_CONTROLFLOW_CHECK_AT_TARGET 0
 #define CINVOKE_DATA_REGNUM 31
 
 static inline const cap_register_t *cheri_get_ddc(CPURISCVState *env) {


### PR DESCRIPTION
Morello checks the bounds at the jump target, so it is possible that the
target PCC is unrepresentable after a jump. I believe this should fix
a "Target addr must be representable" assertion that I saw a while ago.