### PR TITLE
Morello: honor PTE SC and CDBM bits correctly

### DIFF
--- a/target/arm/helper.c
+++ b/target/arm/helper.c
@@ -11755,11 +11755,14 @@ static bool get_phys_addr_lpae(CPUARMState *env, uint64_t address,
 
     int lc = extract32(hwu, 2, 2);
     int sc = extract32(hwu, 1, 1);
-    int cdbm = extract32(hwu, 0, 1);
 
-    // Cap stores can fault here as only tagged stores specify
-    // MMU_DATA_CAP_STORE
-    if (!cdbm && !sc) {
+    /*
+     * Cap stores can fault here as only tagged stores specify
+     * MMU_DATA_CAP_STORE.  QEMU lacks FEAT_HAFDBS support, so we trap on based
+     * on SC alone.  Morello hardware interprets CDBM -- extract32(hwu, 0, 1) --
+     * and a set CDBM will cause it to set SC via CAS in the PTW on cap store.
+     */
+    if (!sc) {
         *prot |= PAGE_SC_TRAP;
         if (access_type == MMU_DATA_CAP_STORE) {
             access_type = base_access_type;


### PR DESCRIPTION
Previously, having either set was sufficient to avoid a trap and SC would not be
set if CDBM were.

CheriBSD is already aware that it may have to set SC itself even if CDBM is set,
so just feed into that logic by raising a trap if SC is clear, ignoring CDBM.

This is, I believe, a sufficient subset of #167.  It should not be merged until CheriBSD has had https://github.com/CTSRD-CHERI/cheribsd/pull/1465 land.