### PR TITLE
[instr logging] Log the faulting instruction before fault side-effects 

### DIFF
--- a/accel/tcg/log_instr.c
+++ b/accel/tcg/log_instr.c
@@ -349,8 +349,12 @@ static void emit_text_entry(CPUArchState *env, cpu_log_instr_info_t *iinfo)
     rcu_read_lock();
     logfile = qatomic_rcu_read(&qemu_logfile);
     if (logfile) {
-        target_disas_buf(logfile->fd, env_cpu(env), iinfo->insn_bytes,
-                         sizeof(iinfo->insn_bytes), iinfo->pc, 1);
+        if (iinfo->insn_size < 1) {
+            fprintf(logfile->fd, "logging exception side effects\n");
+        } else {
+            target_disas_buf(logfile->fd, env_cpu(env), iinfo->insn_bytes,
+                             sizeof(iinfo->insn_bytes), iinfo->pc, 1);
+        }
     }
     rcu_read_unlock();
 

--- a/target/riscv/cpu_helper.c
+++ b/target/riscv/cpu_helper.c
@@ -1190,7 +1190,6 @@ bool riscv_cpu_tlb_fill(CPUState *cs, vaddr address, int size,
 void riscv_cpu_do_interrupt(CPUState *cs)
 {
 #if !defined(CONFIG_USER_ONLY)
-
     RISCVCPU *cpu = RISCV_CPU(cs);
     CPURISCVState *env = &cpu->env;
     tcg_debug_assert(pc_is_current(env));
@@ -1224,10 +1223,10 @@ void riscv_cpu_do_interrupt(CPUState *cs)
         case RISCV_EXCP_LOAD_CAP_PAGE_FAULT:
         case RISCV_EXCP_STORE_AMO_CAP_PAGE_FAULT:
 #endif
-            log_inst = false;
-            /* fallthrough */
         case RISCV_EXCP_INST_ADDR_MIS:
         case RISCV_EXCP_INST_ACCESS_FAULT:
+            log_inst = false;
+            /* fallthrough */
         case RISCV_EXCP_LOAD_ADDR_MIS:
         case RISCV_EXCP_STORE_AMO_ADDR_MIS:
         case RISCV_EXCP_LOAD_ACCESS_FAULT:
@@ -1279,7 +1278,7 @@ void riscv_cpu_do_interrupt(CPUState *cs)
 
     if (unlikely(log_inst && qemu_loglevel_mask(CPU_LOG_INT))) {
         FILE* logf = qemu_log_lock();
-        qemu_log("Trap (%s) was probably caused by: ", riscv_cpu_get_trap_name(cause, async));
+        fprintf(logf, "Trap (%s) was probably caused by: ", riscv_cpu_get_trap_name(cause, async));
         target_disas(logf, cs, PC_ADDR(env), /* Only one instr*/-1);
         qemu_log_unlock(logf);
     }

--- a/target/riscv/cpu_helper.c
+++ b/target/riscv/cpu_helper.c
@@ -892,8 +892,10 @@ void riscv_cpu_do_transaction_failed(CPUState *cs, hwaddr physaddr,
 
     if (access_type == MMU_DATA_STORE) {
         cs->exception_index = RISCV_EXCP_STORE_AMO_ACCESS_FAULT;
-    } else {
+    } else if (access_type == MMU_DATA_LOAD) {
         cs->exception_index = RISCV_EXCP_LOAD_ACCESS_FAULT;
+    } else {
+        cs->exception_index = RISCV_EXCP_INST_ACCESS_FAULT;
     }
 
     env->badaddr = addr;


### PR DESCRIPTION
Previously, we would not log any exception output if we get stuck in an
infinite loop due to an ifetch fault after an exception because the
log_instr_commit only happens when we execute an instruction.

To work around this, we can call qemu_log_instr_commit() before handling
the exception/interrupt and inject a fake instruction to the log buffer
(with size==0 and address -1). A nice side-effect of this change is that
the faulting exception is now decoded according to the mode that the CPU
was in before installing the trap vector. Previously a trap from capmode
to a non-capmode handler would disassemble a capability-relative load
as the integer one since the exception handler PCC was already installed
when the logging performs the disassembly.

Instead of no output, we now print an infinite stream of the following
if we get a trap while trying to jump to the exception handler:
```
[0:0] 0x0000000080000078:  0002c023          csc             cnull,0(ct0)
[0:0] logging exception side effects
-> Switch to Machine mode
-> Exception https://github.com/CTSRD-CHERI/qemu/issues/6 vector 0x0000000000000000 fault-addr 0x0000000080065aa8
    Write mstatus = 0000000a00001800
    Write mcause = 0000000000000006
    Write MEPCC|v:1 s:0 p:00078fff f:1 b:0000000000000000 l:ffffffffffffffff
             |o:0000000080000078 t:000000000003ffff
    Write mbadaddr = 0000000080065aa8
    Write mtval2 = 0000000000000000
    Write PCC|v:1 s:0 p:00078fff f:0 b:0000000000000000 l:ffffffffffffffff
             |o:0000000000000000 t:000000000003ffff
[0:0] logging exception side effects
-> Switch to Machine mode
-> Exception https://github.com/CTSRD-CHERI/qemu/pull/1 vector 0x0000000000000000 fault-addr 0x0000000000000000
    Write mstatus = 0000000a00001800
    Write mcause = 0000000000000001
    Write MEPCC|v:1 s:0 p:00078fff f:0 b:0000000000000000 l:ffffffffffffffff
             |o:0000000000000000 t:000000000003ffff
    Write mbadaddr = 0000000000000000
    Write mtval2 = 0000000000000000
    Write PCC|v:1 s:0 p:00078fff f:0 b:0000000000000000 l:ffffffffffffffff
             |o:0000000000000000 t:000000000003ffff
[0:0] logging exception side effects
-> Switch to Machine mode
-> Exception https://github.com/CTSRD-CHERI/qemu/pull/1 vector 0x0000000000000000 fault-addr 0x0000000000000000
    Write mstatus = 0000000a00001800
    Write mcause = 0000000000000001
    Write MEPCC|v:1 s:0 p:00078fff f:0 b:0000000000000000 l:ffffffffffffffff
             |o:0000000000000000 t:000000000003ffff
    Write mbadaddr = 0000000000000000
    Write mtval2 = 0000000000000000
    Write PCC|v:1 s:0 p:00078fff f:0 b:0000000000000000 l:ffffffffffffffff
             |o:0000000000000000 t:000000000003ffff
```