### PR TITLE
CTestSubset: Compare full top value

### DIFF
--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -1089,7 +1089,7 @@ target_ulong CHERI_HELPER_IMPL(ctestsubset(CPUArchState *env, uint32_t cb,
     if (cbp->cr_tag == ctp->cr_tag &&
         /* is_cap_sealed(cbp) == is_cap_sealed(ctp) && */
         cap_get_base(cbp) <= cap_get_base(ctp) &&
-        cap_get_top(ctp) <= cap_get_top(cbp) &&
+        cap_get_top_full(ctp) <= cap_get_top_full(cbp) &&
         (cap_get_perms(cbp) & cap_get_perms(ctp)) == cap_get_perms(ctp) &&
         (cap_get_uperms(cbp) & cap_get_uperms(ctp)) == cap_get_uperms(ctp)) {
         is_subset = true;


### PR DESCRIPTION
We were comparing the value clamped to UINT64_MAX which resulted in diverging behaviour compared to sail when looking at invalid capabilities.

```
.4byte 0x93420093 # addi x1, x4, -1740
#      Trap: False, PCWD: 0x0000000080000004, RD: 01, RWD: 0xfffffffffffff934, MA: 0x0000000000000000, MWD: 0x0000000000000000, MWM: 0b00000000, I: 0x0000000093420093 PRV_M XL:64 (addi x1, x4, -1740)
.4byte 0xcb10a85b # csetboundsimmediate x16, x1, 3249
#      Trap: False, PCWD: 0x0000000080000008, RD: 16, RWD: 0xfffffffffffff934, MA: 0x0000000000000000, MWD: 0x0000000000000000, MWM: 0b00000000, I: 0x00000000cb10a85b PRV_M XL:64 (csetboundsimmediate x16, x1, 3249)
.4byte 0x41008a5b # ctestsubset x20, x1, x16
#  A < Trap: False, PCWD: 0x000000008000000c, RD: 20, RWD: 0x0000000000000000, MA: 0x0000000000000000, MWD: 0x0000000000000000, MWM: 0b00000000, I: 0x0000000041008a5b PRV_M XL:64 (ctestsubset x20, x1, x16)
#  B > Trap: False, PCWD: 0x000000008000000c, RD: 20, RWD: 0x0000000000000001, MA: 0x0000000000000000, MWD: 0x0000000000000000, MWM: 0b00000000, I: 0x0000000041008a5b PRV_M XL:64 (ctestsubset x20, x1, x16)
```