### PR TITLE
Fix RISCV and CHERI soft-tlb non page-aligned

### DIFF
--- a/target/riscv/pmp.h
+++ b/target/riscv/pmp.h
@@ -72,8 +72,7 @@ void pmpaddr_csr_write(CPURISCVState *env, uint32_t addr_index,
 target_ulong pmpaddr_csr_read(CPURISCVState *env, uint32_t addr_index);
 bool pmp_hart_has_privs(CPURISCVState *env, target_ulong addr,
     target_ulong size, pmp_priv_t priv, target_ulong mode);
-bool pmp_is_range_in_tlb(CPURISCVState *env, hwaddr tlb_sa,
-                         target_ulong *tlb_size);
+bool pmp_covers_page(CPURISCVState *env, hwaddr tlb_byte, target_ulong mode);
 void pmp_update_rule_addr(CPURISCVState *env, uint32_t pmp_index);
 void pmp_update_rule_nums(CPURISCVState *env);
 


### PR DESCRIPTION
The QEMU softtlb only caches (target) page sized ranges. In the case another size is probed, the TLB is filled in but marked as invalid.

CHERI tag setting needs to acknowledge this case.

RISCV also had a completely broken implementation that worked out if the PMP covered an entire page. It tried to mask with a number that was not a power of two, and masking was not appropriate in the first place even had the number been a power of two.

It also ignored priority rules on PMP entry matching, and rules concerning PMP entry matching in M-Mode, and matching rules in non M-Mode where there are no PMP entries.

A lot of these changes could go away if we merged with upstream. They fix the PMP issues, and offer a new probe that returns the struct that tagmem needs without the current ugly hack.