### PR TITLE
Do not cause a GlobalViolation trap in cjalr.

### DIFF
--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -429,8 +429,6 @@ void CHERI_HELPER_IMPL(cjalr(CPUArchState *env, uint32_t cd,
         raise_cheri_exception(env, CapEx_SealViolation, cb);
     } else if (!cap_has_perms(cbp, CAP_PERM_EXECUTE)) {
         raise_cheri_exception(env, CapEx_PermitExecuteViolation, cb);
-    } else if (!cap_has_perms(cbp, CAP_PERM_GLOBAL)) {
-        raise_cheri_exception(env, CapEx_GlobalViolation, cb);
     } else if (!validate_jump_target(env, cbp, addr, cb,
                                      _host_return_address)) {
         assert(false && "Should have raised an exception");


### PR DESCRIPTION
This behaviour is not in the current ISA spec, probably a leftover that was not cleaned up.