### PR TITLE
Fix CI after regressing it when updating cheri-compressed-cap

### DIFF
--- a/target/cheri-common/cheri-lazy-capregs.h
+++ b/target/cheri-common/cheri-lazy-capregs.h
@@ -293,6 +293,7 @@ static inline void update_capreg(CPUArchState *env, unsigned regnum,
     if (unlikely(regnum == NULL_CAPREG_INDEX))
         return;
 
+    cheri_debug_assert(newval->cr_extra == CREG_FULLY_DECOMPRESSED);
     GPCapRegs *gpcrs = cheri_get_gpcrs(env);
     cap_register_t *target = get_cap_in_gpregs(gpcrs, regnum);
     *target = *newval;

--- a/target/cheri-common/cheri_utils.h
+++ b/target/cheri-common/cheri_utils.h
@@ -371,6 +371,7 @@ static inline cap_register_t *cap_mark_unrepresentable(target_ulong addr,
     target_ulong pesbt = CAP_cc(compress_raw)(cr);
     CAP_cc(decompress_raw)(pesbt, addr, false, cr);
 #endif
+    cr->cr_extra = CREG_FULLY_DECOMPRESSED;
     return cr;
 }
 

--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -987,6 +987,14 @@ static void do_setbounds(bool must_be_exact, CPUArchState *env, uint32_t cd,
         (cap_get_top_full(&result) > cap_get_top_full(cbp))) {
         RESULT_VALID = false;
     }
+    /*
+     * Work around bug introduced in cheri-compressed-cap commit
+     *1a3898fa066e9f7e0560ccc95731d5b7f3a7c882 that resulted in the high
+     * bits of the cursor incorrectly being cleared for Morello.
+     * FIXME: remove once we have updatedd cheri-compressed-cap to include
+     * https://github.com/CTSRD-CHERI/cheri-compressed-cap/pull/14
+     */
+    result._cr_cursor = cbp->_cr_cursor;
 #endif
 
     if (RESULT_VALID) {

--- a/tests/morello/test_morello.py
+++ b/tests/morello/test_morello.py
@@ -76,6 +76,7 @@ def find_morello_tests():
                                id=os.path.relpath(fullpath[:-4], tests_dir),
                                marks=marks)
 
+
 @pytest.mark.parametrize("elf_file,should_print_failed", find_morello_tests())
 def test_morello_elf_file(elf_file: Path, should_print_failed: bool, qemu_binary):
     compressed_elf_file = elf_file.with_name(elf_file.name + ".gz")
@@ -106,7 +107,6 @@ def test_morello_elf_file(elf_file: Path, should_print_failed: bool, qemu_binary
     elif status is False and not should_print_failed:
         pytest.fail("Got an unexpected failure message from the test.\nstdout:\n" + result_str + "\n\nstderr:\n" + result_err)
     assert code != 0 or status is True
-    return status
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Since the real fixes have not yet been merged to cheri-compressed-cap and we can work around it with just one added line (and the surrounding code will be removed once we update cheri-compressed-cap) apply a workaround to get CI clean.

Also includes a change to explicitly set cr_extra since the next update of cheri-compressed-cap will initialize the whole struct instead of leaving parts uninitialized.