### PR TITLE
[CHERI-RISC-V] Turn trapping semantics on again

### DIFF
--- a/target/riscv/cheri-archspecific-early.h
+++ b/target/riscv/cheri-archspecific-early.h
@@ -109,7 +109,8 @@ enum CheriSCR {
 #define CHERI_EXC_REGNUM_PCC (32 + CheriSCR_PCC)
 #define CHERI_EXC_REGNUM_DDC (32 + CheriSCR_DDC)
 #define CHERI_CONTROLFLOW_CHECK_AT_TARGET 0
-#define CHERI_TAG_CLEAR_ON_INVALID        1
+/* TODO: switch tag clearing to true once CheriBSD is ready for it. */
+#define CHERI_TAG_CLEAR_ON_INVALID 0
 #define CINVOKE_DATA_REGNUM 31
 
 static inline const cap_register_t *cheri_get_ddc(CPURISCVState *env) {

--- a/target/riscv/csr.c
+++ b/target/riscv/csr.c
@@ -1342,7 +1342,7 @@ static int read_ccsr(CPURISCVState *env, int csrno, target_ulong *val)
     ccsr = set_field(ccsr, XCCSR_ENABLE, cpu->cfg.ext_cheri);
     ccsr = set_field(ccsr, XCCSR_DIRTY, 1); /* Always report dirty */
     /* Read-only feature bits. */
-    ccsr = set_field(ccsr, XCCSR_TAG_CLEARING, 1);
+    ccsr = set_field(ccsr, XCCSR_TAG_CLEARING, CHERI_TAG_CLEAR_ON_INVALID);
 
 #if !defined(TARGET_RISCV32)
     if (csrno == CSR_SCCSR)


### PR DESCRIPTION
The latest CheriBSD release is not ready for these changes and has test failures due to these semantic changes. This will be turned on again in the future but we have to disable it for now as it prevents merges from QEMU dev to qemu-cheri.