### PR TITLE
[CHERI-RISC-V] Allow dynamically enabling ISAv8/v9 semantics

### DIFF
--- a/target/arm/cheri-archspecific-early.h
+++ b/target/arm/cheri-archspecific-early.h
@@ -33,7 +33,7 @@
 #include "cheri-archspecific-earlier.h"
 
 #define CHERI_CONTROLFLOW_CHECK_AT_TARGET 1
-#define CHERI_TAG_CLEAR_ON_INVALID        1
+#define CHERI_TAG_CLEAR_ON_INVALID(env)   1
 
 static inline const cap_register_t *cheri_get_ddc(CPUARMState *env)
 {

--- a/target/mips/cheri-archspecific-early.h
+++ b/target/mips/cheri-archspecific-early.h
@@ -56,7 +56,7 @@
 #define CHERI_REGNUM_IDC  26  /* Invoked Data Capability */
 #define CINVOKE_DATA_REGNUM CHERI_REGNUM_IDC
 #define CHERI_CONTROLFLOW_CHECK_AT_TARGET 0
-#define CHERI_TAG_CLEAR_ON_INVALID        0
+#define CHERI_TAG_CLEAR_ON_INVALID(env)   0
 
 /*
  * QEMU currently tells the kernel that there are no caches installed

--- a/target/riscv/cheri-archspecific-early.h
+++ b/target/riscv/cheri-archspecific-early.h
@@ -110,7 +110,7 @@ enum CheriSCR {
 #define CHERI_EXC_REGNUM_DDC (32 + CheriSCR_DDC)
 #define CHERI_CONTROLFLOW_CHECK_AT_TARGET 0
 /* TODO: switch tag clearing to true once CheriBSD is ready for it. */
-#define CHERI_TAG_CLEAR_ON_INVALID 0
+#define CHERI_TAG_CLEAR_ON_INVALID(env) (env_archcpu(env)->cfg.ext_cheri_v9)
 #define CINVOKE_DATA_REGNUM 31
 
 static inline const cap_register_t *cheri_get_ddc(CPURISCVState *env) {

--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -932,6 +932,7 @@ static Property riscv_cpu_properties[] = {
     DEFINE_PROP_BOOL("Zicsr", RISCVCPU, cfg.ext_icsr, true),
 #ifdef TARGET_CHERI
     DEFINE_PROP_BOOL("Xcheri", RISCVCPU, cfg.ext_cheri, true),
+    DEFINE_PROP_BOOL("Xcheri_v9", RISCVCPU, cfg.ext_cheri_v9, true),
 #endif
     DEFINE_PROP_STRING("priv_spec", RISCVCPU, cfg.priv_spec),
     DEFINE_PROP_STRING("vext_spec", RISCVCPU, cfg.vext_spec),

--- a/target/riscv/cpu.h
+++ b/target/riscv/cpu.h
@@ -418,6 +418,7 @@ struct RISCVCPU {
         bool ext_icsr;
 #ifdef TARGET_CHERI
         bool ext_cheri;
+        bool ext_cheri_v9; /* Temporary flag to support new semantics. */
 #endif
 
         char *priv_spec;

--- a/target/riscv/csr.c
+++ b/target/riscv/csr.c
@@ -1342,7 +1342,7 @@ static int read_ccsr(CPURISCVState *env, int csrno, target_ulong *val)
     ccsr = set_field(ccsr, XCCSR_ENABLE, cpu->cfg.ext_cheri);
     ccsr = set_field(ccsr, XCCSR_DIRTY, 1); /* Always report dirty */
     /* Read-only feature bits. */
-    ccsr = set_field(ccsr, XCCSR_TAG_CLEARING, CHERI_TAG_CLEAR_ON_INVALID);
+    ccsr = set_field(ccsr, XCCSR_TAG_CLEARING, CHERI_TAG_CLEAR_ON_INVALID(env));
 
 #if !defined(TARGET_RISCV32)
     if (csrno == CSR_SCCSR)


### PR DESCRIPTION
Add a new Xcheri_v9 CPU property to enable the new semantics. This allows us to support both semantics within the same QEMU binary which will make it possible to opt into the new semantics for development branches.