### PR TITLE
(bsd-user MTTCG branch) Linux build fixes for system mode

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1580,8 +1580,12 @@ subdir('replay')
 subdir('hw')
 subdir('accel')
 subdir('plugins')
-subdir('bsd-user')
-subdir('linux-user')
+if 'CONFIG_BSD_USER' in config_target
+  subdir('bsd-user')
+endif
+if 'CONFIG_LINUX_USER' in config_target
+  subdir('linux-user')
+endif
 
 bsd_user_ss.add(files('gdbstub.c', 'thunk.c'))
 specific_ss.add_all(when: 'CONFIG_BSD_USER', if_true: bsd_user_ss)
@@ -1783,7 +1787,7 @@ foreach target : target_dirs
     if 'CONFIG_LINUX_USER' in config_target
       base_dir = 'linux-user'
       target_inc += include_directories('linux-user/host/' / config_host['ARCH'])
-    else
+    elif 'CONFIG_BSD_USER' in config_target
       base_dir = 'bsd-user'
       target_inc += include_directories(
         base_dir / 'host' / config_host['ARCH'],

--- a/target/cheri-common/cheri_tagmem.c
+++ b/target/cheri-common/cheri_tagmem.c
@@ -33,11 +33,11 @@
  * SUCH DAMAGE.
  */
 #include "cheri_tagmem.h"
-#include "cheri_usermem.h"
 #include "exec/exec-all.h"
 #include "exec/log.h"
 #include "exec/ramblock.h"
 #ifdef CONFIG_USER_ONLY
+#include "cheri_usermem.h"
 #include "qemu.h"
 #else
 #include "hw/boards.h"


### PR DESCRIPTION
Fix the build for the bsd-user branch to build riscv64cheri-softmmu system-mode on Linux.  Currently the codebase throws an assertion failure in early BBL/CheriBSD boot (even without `-accel tcg,thread=multi`):

```
$ ~/cheri/output/sdk/bin/qemu-system-riscv64cheri -M virt -m 2048 -nographic -bios bbl-riscv64cheri-virt-fw_jump.bin -kernel ~/cheri/output/rootfs-riscv64-purecap/boot/kernel/kernel -drive if=none,file=~/cheri/output/cheribsd-riscv64-purecap.img,id=drv,format=raw -device virtio-blk-device,drive=drv -smp 2 -s -serial mon:stdio -serial pty -monitor tcp:127.0.0.1:5555,server,nowait -device virtio-net-device,netdev=net0 -netdev tap,id=net0,ifname=tap0,script=no,downscript=no -D trace.log -append -v
char device redirected to /dev/pts/10 (label serial1)
bbl loader
SoC version: unknown
Hart 0 version: unknown
Hart 1 version: unknown
qemu-system-riscv64cheri: ../../qemu/target/cheri-common/cheri_tagmem.c:851: void invalidate_from_locktag(lock_tag *): Assertion `lock != TAG_LOCK_ERROR' failed.
qemu-system-riscv64cheri: ../../qemu/target/cheri-common/cheri_tagmem.c:851: void invalidate_from_locktag(lock_tag *): Assertion `lock != TAG_LOCK_ERROR' failed.
```
