### PR TITLE
Enable CHERIv9 semantics by default

### DIFF
--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -968,7 +968,7 @@ static Property riscv_cpu_properties[] = {
     DEFINE_PROP_BOOL("Zicsr", RISCVCPU, cfg.ext_icsr, true),
 #ifdef TARGET_CHERI
     DEFINE_PROP_BOOL("Xcheri", RISCVCPU, cfg.ext_cheri, true),
-    DEFINE_PROP_BOOL("Xcheri_v9", RISCVCPU, cfg.ext_cheri_v9, false),
+    DEFINE_PROP_BOOL("Xcheri_v9", RISCVCPU, cfg.ext_cheri_v9, true),
 #endif
     DEFINE_PROP_STRING("priv_spec", RISCVCPU, cfg.priv_spec),
     DEFINE_PROP_STRING("vext_spec", RISCVCPU, cfg.vext_spec),


### PR DESCRIPTION
I believe CheriBSD has been ready for this switch for a long time. Importantly, LLVM will not assume these new semantics yet, so potentially trapping CHERI instructions will not be hoisted.