### PR TITLE
Fix gcc 14 warnings

### DIFF
--- a/accel/tcg/log_instr.c
+++ b/accel/tcg/log_instr.c
@@ -1303,7 +1303,7 @@ void qemu_log_gen_printf(DisasContextBase *base, const char *qemu_format,
          */
         char c;
         bool format = false;
-        bool is_short, is_long, is_long_long, is_signed;
+        bool is_short = false, is_long = false, is_long_long = false, is_signed = false;
 
         while ((c = *fmt++)) {
             if (!format) {

--- a/accel/tcg/log_instr.c
+++ b/accel/tcg/log_instr.c
@@ -473,10 +473,13 @@ static void emit_cvtrace_entry(CPUArchState *env, cpu_log_instr_info_t *iinfo)
     switch (iinfo->flags & LI_FLAG_INTR_MASK) {
     case LI_FLAG_INTR_TRAP:
         entry.exception = (uint8_t)(iinfo->intr_code & 0xff);
+        break;
     case LI_FLAG_INTR_ASYNC:
         entry.exception = 0;
+        break;
     default:
         entry.exception = CTE_EXCEPTION_NONE;
+        break;
     }
 
     if (iinfo->regs->len) {

--- a/accel/tcg/log_instr.c
+++ b/accel/tcg/log_instr.c
@@ -1216,7 +1216,7 @@ static void g_string_append_printf_union_args(GString *string, const char *fmt,
 
     g_string_append_printf(string, bounce_buf);
 
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 }
 
 static TCGv_i64 qemu_log_printf_valid_entries;

--- a/accel/tcg/log_instr.c
+++ b/accel/tcg/log_instr.c
@@ -1325,6 +1325,7 @@ void qemu_log_gen_printf(DisasContextBase *base, const char *qemu_format,
             case 'd':
             case 'i':
                 is_signed = true;
+                QEMU_FALLTHROUGH;
             case 'u':
             case 'x':
             case 'X':

--- a/accel/tcg/log_instr.c
+++ b/accel/tcg/log_instr.c
@@ -1005,18 +1005,6 @@ static inline void qemu_log_instr_mem_int(CPUArchState *env, target_ulong addr,
     g_array_append_val(iinfo->mem, m);
 }
 
-void qemu_log_instr_ld_int(CPUArchState *env, target_ulong addr, MemOpIdx oi,
-                           target_ulong value)
-{
-    qemu_log_instr_mem_int(env, addr, LMI_LD, oi, value);
-}
-
-void qemu_log_instr_st_int(CPUArchState *env, target_ulong addr, MemOpIdx oi,
-                           target_ulong value)
-{
-    qemu_log_instr_mem_int(env, addr, LMI_ST, oi, value);
-}
-
 #ifdef TARGET_CHERI
 /*
  * Note: logging the value here may be redundant as the capability is

--- a/accel/tcg/log_instr.c
+++ b/accel/tcg/log_instr.c
@@ -1372,6 +1372,7 @@ void qemu_log_gen_printf(DisasContextBase *base, const char *qemu_format,
                 if (t == 'c') {
                     arg_const = (uint64_t)va_arg(args, void *);
                 }
+                QEMU_FALLTHROUGH;
             case '%':
                 format = false;
                 break;

--- a/fpu/softfloat.c
+++ b/fpu/softfloat.c
@@ -874,10 +874,10 @@ static FloatParts128 *parts128_minmax(FloatParts128 *a, FloatParts128 *b,
 #define parts_minmax(A, B, S, F) \
     PARTS_GENERIC_64_128(minmax, A)(A, B, S, F)
 
-static int parts64_compare(FloatParts64 *a, FloatParts64 *b,
-                           float_status *s, bool q);
-static int parts128_compare(FloatParts128 *a, FloatParts128 *b,
-                            float_status *s, bool q);
+static FloatRelation parts64_compare(FloatParts64 *a, FloatParts64 *b,
+                                     float_status *s, bool q);
+static FloatRelation parts128_compare(FloatParts128 *a, FloatParts128 *b,
+                                      float_status *s, bool q);
 
 #define parts_compare(A, B, S, Q) \
     PARTS_GENERIC_64_128(compare, A)(A, B, S, Q)

--- a/hw/arm/armtrickbox.c
+++ b/hw/arm/armtrickbox.c
@@ -200,12 +200,15 @@ static void arm_trickbox_write(void *opaque, hwaddr addr, uint64_t val,
 #define HANDLE_WRITE(name, resetv, readmask, writemask, writefn, ...)          \
     CASE_HANDLE(name)                                                          \
     __VA_ARGS__                                                                \
-    old = tb->name;                                                            \
-    tb->name = (tb->name & ~writemask) | (val & writemask);                    \
-    if (writefn) {                                                             \
-        ((write_helper_fn *)writefn)(tb, addr, &tb->name, old);                \
-    }                                                                          \
-    break;                                                                     \
+    {                                                                          \
+        old = tb->name;                                                        \
+        tb->name = (tb->name & ~writemask) | (val & writemask);                \
+        write_helper_fn *write_handler = writefn;                              \
+        if (write_handler) {                                                   \
+            write_handler(tb, addr, &tb->name, old);                           \
+        }                                                                      \
+        break;                                                                 \
+    }
 
     REGISTER_LIST(HANDLE_WRITE, CASE_HANDLE)
 

--- a/include/exec/log_instr.h
+++ b/include/exec/log_instr.h
@@ -250,18 +250,6 @@ void qemu_log_instr_commit(CPUArchState *env);
 void qemu_log_instr_reg(CPUArchState *env, const char *reg_name,
                         target_ulong value);
 
-/*
- * Log integer memory load.
- */
-void qemu_log_instr_ld_int(CPUArchState *env, target_ulong addr, MemOp op,
-                           target_ulong value);
-
-/*
- * Log integer memory store.
- */
-void qemu_log_instr_st_int(CPUArchState *env, target_ulong addr, MemOp op,
-                           target_ulong value);
-
 #ifdef TARGET_CHERI
 /*
  * Log changed capability register.

--- a/include/tcg/tcg-op.h
+++ b/include/tcg/tcg-op.h
@@ -889,9 +889,6 @@ static inline void tcg_gen_plugin_cb_end(void)
 #define tcg_gen_qemu_st_i32 tcg_gen_qemu_st_i32_with_checked_addr
 #define tcg_gen_qemu_ld_i64 tcg_gen_qemu_ld_i64_with_checked_addr
 #define tcg_gen_qemu_st_i64 tcg_gen_qemu_st_i64_with_checked_addr
-void tcg_gen_qemu_st_i32(TCGv_i32, TCGv, TCGArg, MemOp);
-void tcg_gen_qemu_ld_i64(TCGv_i64, TCGv, TCGArg, MemOp);
-void tcg_gen_qemu_st_i64(TCGv_i64, TCGv, TCGArg, MemOp);
 #define TCG_LD_HELPER(name, memop)                                             \
     static inline void tcg_gen_qemu_##name(TCGv ret, TCGv addr,                \
                                            int mem_index) {                    \

--- a/replay/replay-internal.h
+++ b/replay/replay-internal.h
@@ -141,7 +141,7 @@ bool replay_next_event_is(int event);
 /*! Reads next clock value from the file.
     If clock kind read from the file is different from the parameter,
     the value is not used. */
-void replay_read_next_clock(unsigned int kind);
+void replay_read_next_clock(ReplayClockKind kind);
 
 /* Asynchronous events queue */
 

--- a/scripts/decodetree.py
+++ b/scripts/decodetree.py
@@ -899,7 +899,7 @@ def parse_generic(lineno, parent_pat, name, toks):
             continue
 
         # '?Foo' and '?!Foo' give a pattern a dynamic predicate.
-        if re.fullmatch('\?!?' + re_C_ident, t):
+        if re.fullmatch(r'\?!?' + re_C_ident, t):
             tt = t[1:]
             preds.append(tt)
             continue

--- a/stubs/replay-tools.c
+++ b/stubs/replay-tools.c
@@ -7,13 +7,14 @@ bool replay_events_enabled(void)
     return false;
 }
 
-int64_t replay_save_clock(unsigned int kind, int64_t clock, int64_t raw_icount)
+int64_t replay_save_clock(ReplayClockKind kind,
+                          int64_t clock, int64_t raw_icount)
 {
     abort();
     return 0;
 }
 
-int64_t replay_read_clock(unsigned int kind, int64_t raw_icount)
+int64_t replay_read_clock(ReplayClockKind kind, int64_t raw_icount)
 {
     abort();
     return 0;
@@ -48,11 +49,11 @@ void replay_mutex_unlock(void)
 {
 }
 
-void replay_register_char_driver(Chardev *chr)
+void replay_register_char_driver(struct Chardev *chr)
 {
 }
 
-void replay_chr_be_write(Chardev *s, uint8_t *buf, int len)
+void replay_chr_be_write(struct Chardev *s, uint8_t *buf, int len)
 {
     abort();
 }

--- a/target/arm/cheri-archspecific-early.h
+++ b/target/arm/cheri-archspecific-early.h
@@ -34,10 +34,6 @@
 
 #define CHERI_CONTROLFLOW_CHECK_AT_TARGET 1
 #define CHERI_TAG_CLEAR_ON_INVALID(env)   1
-struct DisasContext;
-static inline bool cctlr_set(struct DisasContext *ctx, uint32_t bits);
-#define CHERI_TRANSLATE_DDC_RELOCATION(ctx) cctlr_set(ctx, CCTLR_DDCBO)
-#define CHERI_TRANSLATE_PCC_RELOCATION(ctx) cctlr_set(ctx, CCTLR_PCCBO)
 
 static inline const cap_register_t *cheri_get_ddc(CPUARMState *env)
 {

--- a/target/arm/cheri-archspecific-translate.h
+++ b/target/arm/cheri-archspecific-translate.h
@@ -1,0 +1,11 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2025 Alex Richardson
+ */
+
+#pragma once
+
+static inline bool cctlr_set(struct DisasContext *ctx, uint32_t bits);
+#define CHERI_TRANSLATE_DDC_RELOCATION(ctx) cctlr_set(ctx, CCTLR_DDCBO)
+#define CHERI_TRANSLATE_PCC_RELOCATION(ctx) cctlr_set(ctx, CCTLR_PCCBO)

--- a/target/arm/cheri-archspecific-translate.h
+++ b/target/arm/cheri-archspecific-translate.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#ifdef TARGET_CHERI
 static inline bool cctlr_set(struct DisasContext *ctx, uint32_t bits);
 #define CHERI_TRANSLATE_DDC_RELOCATION(ctx) cctlr_set(ctx, CCTLR_DDCBO)
 #define CHERI_TRANSLATE_PCC_RELOCATION(ctx) cctlr_set(ctx, CCTLR_PCCBO)
+#endif

--- a/target/arm/cheri-archspecific.h
+++ b/target/arm/cheri-archspecific.h
@@ -85,9 +85,6 @@ static inline ARMFaultType cheri_cause_to_arm_fault(CheriCapExcCause cause)
     }
 }
 
-void QEMU_NORETURN raise_exception(CPUARMState *env, uint32_t excp,
-                                   uint32_t syndrome, uint32_t target_el);
-
 static inline void QEMU_NORETURN raise_cheri_exception_impl_if_wnr(
     CPUArchState *env, CheriCapExcCause cause, unsigned regnum,
     target_ulong addr, bool instavail, uintptr_t hostpc, bool instruction_fetch,

--- a/target/arm/cheri-archspecific.h
+++ b/target/arm/cheri-archspecific.h
@@ -21,6 +21,7 @@
 
 #define CAP_TAG_GET_MANY_SHFT 2
 
+#include "exec/exec-all.h"
 #include "internals.h"
 
 typedef enum CheriCapExc {

--- a/target/arm/cheri-archspecific.h
+++ b/target/arm/cheri-archspecific.h
@@ -123,8 +123,6 @@ static inline void QEMU_NORETURN raise_cheri_exception_impl_if_wnr(
                     syn, target_el);
 }
 
-static inline const char *cheri_cause_str(CheriCapExcCause cause);
-
 static inline void QEMU_NORETURN raise_cheri_exception_impl(
     CPUArchState *env, CheriCapExcCause cause, unsigned regnum,
     target_ulong addr, bool instavail, uintptr_t hostpc)

--- a/target/arm/translate-cheri.inc.c
+++ b/target/arm/translate-cheri.inc.c
@@ -162,6 +162,7 @@ static inline bool gen_cheri_addr_op_tcgval(DisasContext *ctx, int cd,
         break;
     case OP_ALIGN_UP:
         tcg_gen_add_i64(result, result, val);
+        QEMU_FALLTHROUGH;
     case OP_ALIGN_DOWN:
         tcg_gen_andc_i64(result, result, val);
         break;

--- a/target/arm/translate-cheri.inc.c
+++ b/target/arm/translate-cheri.inc.c
@@ -130,6 +130,7 @@ static inline bool gen_cheri_addr_op_imm(DisasContext *ctx, int cd,
         break;
     case OP_ALIGN_UP:
         tcg_gen_addi_i64(result, result, val);
+        QEMU_FALLTHROUGH;
     case OP_ALIGN_DOWN:
         tcg_gen_andi_i64(result, result, ~val);
         break;
@@ -152,6 +153,7 @@ static inline bool gen_cheri_addr_op_tcgval(DisasContext *ctx, int cd,
     switch (op) {
     case OP_SET:
         tcg_gen_andi_i64(result, result, ~(0xFFULL << 56));
+        QEMU_FALLTHROUGH;
     case OP_OR:
         tcg_gen_or_i64(result, result, val);
         break;

--- a/target/cheri-common/cheri-bounds-stats.h
+++ b/target/cheri-common/cheri-bounds-stats.h
@@ -38,7 +38,6 @@
 #include "cheri_utils.h"
 #include "cheri-archspecific.h"
 #include "qemu/qemu-print.h"
-#include "cheri-archspecific.h"
 
 extern bool cheri_c2e_on_unrepresentable;
 extern bool cheri_debugger_on_unrepresentable;

--- a/target/cheri-common/cheri-helper-common.h
+++ b/target/cheri-common/cheri-helper-common.h
@@ -122,10 +122,10 @@ DEF_HELPER_4(csetflags, void, env, i32, i32, tl)
 DEF_HELPER_4(csetoffset, void, env, i32, i32, tl)
 
 // Three operands (int cap cap)
-DEF_HELPER_FLAGS_3(csub, 0, tl, env, i32, i32)
-DEF_HELPER_FLAGS_3(ctestsubset, 0, tl, env, i32, i32)
-DEF_HELPER_FLAGS_3(cseqx, 0, tl, env, i32, i32)
-DEF_HELPER_FLAGS_3(ctoptr, 0, tl, env, i32, i32)
+DEF_HELPER_3(csub, tl, env, i32, i32)
+DEF_HELPER_3(ctestsubset, tl, env, i32, i32)
+DEF_HELPER_3(cseqx, tl, env, i32, i32)
+DEF_HELPER_3(ctoptr, tl, env, i32, i32)
 
 // Loads+Stores
 /*

--- a/target/cheri-common/cheri-helper-utils.h
+++ b/target/cheri-common/cheri-helper-utils.h
@@ -43,6 +43,14 @@
 #include "tcg/tcg-op.h"
 #include "exec/exec-all.h"
 
+static inline target_ulong cpu_get_current_pc(CPUArchState *env,
+                                              uintptr_t retpc, bool will_exit)
+{
+    cpu_restore_state(env_cpu(env), retpc, will_exit);
+    cheri_debug_assert(pc_is_current(env));
+    return cpu_get_recent_pc(env);
+}
+
 static inline void derive_cap_from_pcc(CPUArchState *env, uint32_t cd,
                                        target_ulong new_addr, uintptr_t retpc,
                                        struct oob_stats_info *oob_info)

--- a/target/cheri-common/cheri-lazy-capregs.h
+++ b/target/cheri-common/cheri-lazy-capregs.h
@@ -45,8 +45,6 @@
 #include "qemu/log.h"
 #include "exec/log_instr.h"
 
-static inline GPCapRegs *cheri_get_gpcrs(CPUArchState *env);
-
 static inline QEMU_ALWAYS_INLINE CapRegState
 get_capreg_state(const GPCapRegs *gpcrs, unsigned reg)
 {

--- a/target/cheri-common/cheri-translate-utils.h
+++ b/target/cheri-common/cheri-translate-utils.h
@@ -97,7 +97,6 @@ _gen_cap_check(rmw)
 #ifdef TARGET_MIPS
 
 #define DDC_ENV_OFFSET offsetof(CPUArchState, active_tc.CHWR.DDC)
-void gen_load_gpr(TCGv t, int reg);
 #define target_get_gpr(ctx, t, reg) gen_load_gpr((TCGv)t, reg)
 #define MERGED_FILE 0
 

--- a/target/cheri-common/cheri-translate-utils.h
+++ b/target/cheri-common/cheri-translate-utils.h
@@ -113,7 +113,6 @@ _gen_cap_check(rmw)
 #define BOUNDS_DO_NOT_WRAP
 #define TRACE_MODIFIED_REGISTERS
 
-TCGv_i64 cpu_reg(DisasContext *s, int reg);
 #define target_get_gpr_global(ctx, reg) cpu_reg_sp(ctx, reg)
 #define target_get_gpr(ctx, t, reg)                                            \
     if (reg == NULL_CAPREG_INDEX)                                              \

--- a/target/cheri-common/cheri-translate-utils.h
+++ b/target/cheri-common/cheri-translate-utils.h
@@ -36,6 +36,7 @@
 #include "cheri-translate-utils-base.h"
 #include "cheri-lazy-capregs-types.h"
 #include "tcg-target.h"
+#include "cheri-archspecific-translate.h"
 #include "exec/log_instr.h"
 
 #ifdef TARGET_CHERI

--- a/target/cheri-common/cheri_defs.h
+++ b/target/cheri-common/cheri_defs.h
@@ -37,6 +37,7 @@
 #else
 # define cheri_debug_assert(X) ((void)0)
 #endif
+#define GET_HOST_RETPC() const uintptr_t _host_return_address = GETPC()
 
 #ifdef TARGET_CHERI
 

--- a/target/cheri-common/cheri_tagmem.c
+++ b/target/cheri-common/cheri_tagmem.c
@@ -348,18 +348,19 @@ typedef struct TagOffset {
     target_ulong value;
 } TagOffset;
 
-static QEMU_ALWAYS_INLINE TagOffset addr_to_tag_offset(target_ulong addr)
+static inline QEMU_ALWAYS_INLINE TagOffset addr_to_tag_offset(target_ulong addr)
 {
     return (struct TagOffset){.value = addr / CHERI_CAP_SIZE};
 }
 
-static QEMU_ALWAYS_INLINE target_ulong
+static inline QEMU_ALWAYS_INLINE target_ulong
 page_vaddr_to_tag_offset(target_ulong addr)
 {
     return (addr & ~TARGET_PAGE_MASK) / CHERI_CAP_SIZE;
 }
 
-static QEMU_ALWAYS_INLINE target_ulong tag_offset_to_addr(TagOffset offset)
+static inline QEMU_ALWAYS_INLINE target_ulong
+tag_offset_to_addr(TagOffset offset)
 {
     return offset.value * CHERI_CAP_SIZE;
 }

--- a/target/cheri-common/cheri_utils.h
+++ b/target/cheri-common/cheri_utils.h
@@ -133,8 +133,9 @@ static inline bool cap_otype_is_reserved(target_ulong otype)
 {
     cheri_debug_assert(otype <= CAP_MAX_REPRESENTABLE_OTYPE &&
                        "Should only be called for in-range otypes!");
-    return otype >= CAP_CC(MIN_RESERVED_OTYPE) &&
-           otype <= CAP_CC(MAX_RESERVED_OTYPE);
+    /* Silence -Wtype-limits by using an intermediate variable. */
+    target_ulong min = CAP_CC(MIN_RESERVED_OTYPE);
+    return otype >= min && otype <= CAP_CC(MAX_RESERVED_OTYPE);
 }
 
 static inline target_ulong cap_get_otype_unsigned(const cap_register_t *c)

--- a/target/cheri-common/cheri_utils.h
+++ b/target/cheri-common/cheri_utils.h
@@ -62,8 +62,6 @@
 #define PRINT_CAP_FMTSTR PRINT_CAP_FMTSTR_L1 " " PRINT_CAP_FMTSTR_L2
 #define PRINT_CAP_ARGS(cr) PRINT_CAP_ARGS_L1(cr), PRINT_CAP_ARGS_L2(cr)
 
-#define GET_HOST_RETPC() const uintptr_t _host_return_address = GETPC()
-
 #ifdef TARGET_CHERI
 
 static inline target_ulong cap_get_cursor(const cap_register_t *c)

--- a/target/cheri-common/cpu_cheri.h
+++ b/target/cheri-common/cpu_cheri.h
@@ -37,12 +37,13 @@
 #pragma once
 // This file should be included from cpu.h after CPURISCVState has been defined
 #include "qemu/log.h"
-#include "cheri_utils.h"
+#include "cheri_defs.h"
 
 static inline bool pc_is_current(CPUArchState *env);
 static inline target_ulong cpu_get_recent_pc(CPUArchState *env);
 
 #ifdef TARGET_CHERI
+#include "cheri_utils.h"
 static inline const cap_register_t *_cheri_get_pcc_unchecked(CPUArchState *env);
 #include "cheri-archspecific-early.h"
 // Returns a recent PCC value. This means that the cursor field may be out of

--- a/target/cheri-common/cpu_cheri.h
+++ b/target/cheri-common/cpu_cheri.h
@@ -39,7 +39,6 @@
 #include "qemu/log.h"
 #include "cheri_utils.h"
 
-bool cpu_restore_state(CPUState *cpu, uintptr_t host_pc, bool will_exit);
 static inline bool pc_is_current(CPUArchState *env);
 static inline target_ulong cpu_get_recent_pc(CPUArchState *env);
 
@@ -65,13 +64,6 @@ static inline const cap_register_t *cheri_get_current_pcc(CPUArchState *env)
 {
     cheri_debug_assert(pc_is_current(env));
     return _cheri_get_pcc_unchecked(env);
-}
-
-static inline const cap_register_t *
-cheri_get_current_pcc_fetch_from_tcg(CPUArchState *env, uintptr_t retpc)
-{
-    cpu_restore_state(env_cpu(env), retpc, false);
-    return cheri_get_current_pcc(env);
 }
 
 static inline void cheri_update_pcc(cap_register_t *pcc, target_ulong pc_addr,
@@ -167,14 +159,6 @@ static inline void cheri_cpu_get_tb_cpu_state(const cap_register_t *pcc,
 }
 
 #endif
-
-static inline target_ulong cpu_get_current_pc(CPUArchState *env,
-                                              uintptr_t retpc, bool will_exit)
-{
-    cpu_restore_state(env_cpu(env), retpc, will_exit);
-    cheri_debug_assert(pc_is_current(env));
-    return cpu_get_recent_pc(env);
-}
 
 static inline target_ulong cpu_get_current_pc_checked(CPUArchState *env)
 {

--- a/target/mips/cheri-archspecific-early.h
+++ b/target/mips/cheri-archspecific-early.h
@@ -57,8 +57,6 @@
 #define CINVOKE_DATA_REGNUM CHERI_REGNUM_IDC
 #define CHERI_CONTROLFLOW_CHECK_AT_TARGET 0
 #define CHERI_TAG_CLEAR_ON_INVALID(env)   0
-#define CHERI_TRANSLATE_DDC_RELOCATION(ctx) 1
-#define CHERI_TRANSLATE_PCC_RELOCATION(ctx) 1
 
 /*
  * QEMU currently tells the kernel that there are no caches installed

--- a/target/mips/cheri-archspecific-translate.h
+++ b/target/mips/cheri-archspecific-translate.h
@@ -1,0 +1,10 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2025 Alex Richardson
+ */
+
+#pragma once
+
+#define CHERI_TRANSLATE_DDC_RELOCATION(ctx) 1
+#define CHERI_TRANSLATE_PCC_RELOCATION(ctx) 1

--- a/target/mips/cheri-archspecific.h
+++ b/target/mips/cheri-archspecific.h
@@ -40,6 +40,7 @@
 
 #include "cheri-archspecific-early.h"
 #include "cheri_defs.h"
+#include "exec/exec-all.h"
 #include "internal.h"
 
 static inline const char* cheri_cause_str(CheriCapExcCause cause);
@@ -57,11 +58,13 @@ static inline QEMU_NORETURN void do_raise_c2_exception_impl(CPUMIPSState *env,
     }
 
     if (qemu_log_instr_or_mask_enabled(env, CPU_LOG_INT)) {
-        qemu_log_instr_or_mask_msg(env, CPU_LOG_INT,
+        cpu_restore_state(env_cpu(env), hostpc, true);
+        qemu_log_instr_or_mask_msg(
+            env, CPU_LOG_INT,
             "C2 EXCEPTION: cause=%d(%s) reg=%d PCC=" PRINT_CAP_FMTSTR
-            " -> host PC: 0x%jx\n", cause, cheri_cause_str(cause), reg,
-            PRINT_CAP_ARGS(cheri_get_current_pcc_fetch_from_tcg(env, hostpc)),
-            (uintmax_t)hostpc);
+            " -> host PC: 0x%jx\n",
+            cause, cheri_cause_str(cause), reg,
+            PRINT_CAP_ARGS(cheri_get_current_pcc(env)), (uintmax_t)hostpc);
     }
 #ifdef DEBUG_KERNEL_CP2_VIOLATION
     if (in_kernel_mode(env)) {

--- a/target/mips/internal.h
+++ b/target/mips/internal.h
@@ -99,7 +99,6 @@ static inline bool cheri_have_access_sysregs(CPUArchState *env);
 int mips_gdb_get_sys_reg(CPUMIPSState *env, GByteArray *buf, int n);
 int mips_gdb_set_sys_reg(CPUMIPSState *env, uint8_t *mem_buf, int n);
 
-hwaddr mips_cpu_get_phys_page_debug(CPUState *cpu, vaddr addr);
 int mips_cpu_gdb_read_register(CPUState *cpu, GByteArray *buf, int reg);
 int mips_cpu_gdb_write_register(CPUState *cpu, uint8_t *buf, int reg);
 

--- a/target/mips/internal.h
+++ b/target/mips/internal.h
@@ -100,7 +100,6 @@ int mips_gdb_get_sys_reg(CPUMIPSState *env, GByteArray *buf, int n);
 int mips_gdb_set_sys_reg(CPUMIPSState *env, uint8_t *mem_buf, int n);
 
 void mips_cpu_do_interrupt(CPUState *cpu);
-bool mips_cpu_exec_interrupt(CPUState *cpu, int int_req);
 hwaddr mips_cpu_get_phys_page_debug(CPUState *cpu, vaddr addr);
 int mips_cpu_gdb_read_register(CPUState *cpu, GByteArray *buf, int reg);
 int mips_cpu_gdb_write_register(CPUState *cpu, uint8_t *buf, int reg);

--- a/target/mips/internal.h
+++ b/target/mips/internal.h
@@ -99,7 +99,6 @@ static inline bool cheri_have_access_sysregs(CPUArchState *env);
 int mips_gdb_get_sys_reg(CPUMIPSState *env, GByteArray *buf, int n);
 int mips_gdb_set_sys_reg(CPUMIPSState *env, uint8_t *mem_buf, int n);
 
-void mips_cpu_do_interrupt(CPUState *cpu);
 hwaddr mips_cpu_get_phys_page_debug(CPUState *cpu, vaddr addr);
 int mips_cpu_gdb_read_register(CPUState *cpu, GByteArray *buf, int reg);
 int mips_cpu_gdb_write_register(CPUState *cpu, uint8_t *buf, int reg);

--- a/target/mips/internal.h
+++ b/target/mips/internal.h
@@ -94,6 +94,7 @@ extern const int mips_defs_number;
 
 int mips_gdb_get_cheri_reg(CPUMIPSState *env, GByteArray *buf, int n);
 int mips_gdb_set_cheri_reg(CPUMIPSState *env, uint8_t *mem_buf, int n);
+static inline bool cheri_have_access_sysregs(CPUArchState *env);
 #endif
 int mips_gdb_get_sys_reg(CPUMIPSState *env, GByteArray *buf, int n);
 int mips_gdb_set_sys_reg(CPUMIPSState *env, uint8_t *mem_buf, int n);
@@ -318,15 +319,12 @@ static inline int mips_vp_active(CPUMIPSState *env)
     return 1;
 }
 
-static inline bool cheri_have_access_sysregs(CPUArchState *env);
-
 static inline bool can_access_cp0(CPUMIPSState* env) {
     if (((env->CP0_Status & (1 << CP0St_CU0)) &&
         !(env->insn_flags & ISA_MIPS_R6)) ||
         !(env->hflags & MIPS_HFLAG_KSU)) {
 #ifdef TARGET_CHERI
         // For CHERI we need to check PCC.perms before enabling access to cp0 features.
-        // XXX: can't use cheri_have_access_sysregs() here due to cyclic deps
         if (!cheri_have_access_sysregs(env)) {
             /* qemu_log_mask(CPU_LOG_INSTR, "Kernel mode but no ASR!\n"); */
             return false;

--- a/target/mips/internal.h
+++ b/target/mips/internal.h
@@ -253,7 +253,6 @@ static inline void mips_env_set_pc(CPUMIPSState *env, target_ulong value)
     }
 }
 
-
 static inline void restore_pamask(CPUMIPSState *env)
 {
     if (env->hflags & MIPS_HFLAG_ELPA) {

--- a/target/mips/tcg/sysemu/op_helper_magic.c
+++ b/target/mips/tcg/sysemu/op_helper_magic.c
@@ -665,6 +665,7 @@ void helper_magic_library_function(CPUMIPSState *env, target_ulong which)
                         lookup_symbol(PC_ADDR(env)), ((which & UINT32_MAX) == 0xf0 ? "entry" : "exit"), len, src);
             }
         }
+        break;
     }
     case 0xfe:
     case 0xff:

--- a/target/mips/tcg/translate.c
+++ b/target/mips/tcg/translate.c
@@ -5438,7 +5438,7 @@ static void gen_compute_branch(DisasContext *ctx, uint32_t opc,
 #ifndef TARGET_CHERI
         case OPC_JALX:
             ctx->hflags |= MIPS_HFLAG_BX;
-            /* Fallthrough */
+            QEMU_FALLTHROUGH;
 #endif
         case OPC_JAL:
             blink = 31;

--- a/target/mips/tcg/translate.c
+++ b/target/mips/tcg/translate.c
@@ -1615,12 +1615,12 @@ void generate_exception_err(DisasContext *ctx, MipsExcp excp, int err)
     ctx->base.is_jmp = DISAS_NORETURN;
 }
 
-void generate_exception(DisasContext *ctx, int excp)
+void generate_exception(DisasContext *ctx, MipsExcp excp)
 {
     gen_helper_raise_exception(cpu_env, tcg_constant_i32(excp));
 }
 
-void generate_exception_end(DisasContext *ctx, int excp)
+void generate_exception_end(DisasContext *ctx, MipsExcp excp)
 {
     generate_exception_err(ctx, excp, 0);
 }

--- a/target/mips/tcg/translate.c
+++ b/target/mips/tcg/translate.c
@@ -15803,17 +15803,16 @@ static void decode_opc_special3(CPUMIPSState *env, DisasContext *ctx)
 {
     int rs, rt, rd, sa;
     uint32_t op1, op2;
-    int16_t imm;
 
     rs = (ctx->opcode >> 21) & 0x1f;
     rt = (ctx->opcode >> 16) & 0x1f;
     rd = (ctx->opcode >> 11) & 0x1f;
     sa = (ctx->opcode >> 6) & 0x1f;
-    imm = sextract32(ctx->opcode, 7, 9);
 
     op1 = MASK_SPECIAL3(ctx->opcode);
 
 #ifndef TARGET_CHERI
+    int16_t imm = sextract32(ctx->opcode, 7, 9);
     /*
      * EVA loads and stores overlap Loongson 2E instructions decoded by
      * decode_opc_special3_legacy(), so be careful to allow their decoding when

--- a/target/mips/tcg/translate.c
+++ b/target/mips/tcg/translate.c
@@ -38,9 +38,7 @@
 #include "qemu/qemu-print.h"
 #include "fpu_helper.h"
 #include "translate.h"
-#ifdef TARGET_CHERI
-#include "cheri-helper-utils.h"
-#endif
+#include "cheri-translate-utils.h"
 
 
 /*
@@ -1559,7 +1557,6 @@ static inline void gen_save_pc(target_ulong pc)
     tcg_gen_movi_tl(_pc_is_current, 1); // PC has been updated.
 #endif
 }
-#include "cheri-translate-utils.h"
 
 static inline void save_cpu_state(DisasContext *ctx, int do_save_pc)
 {

--- a/target/mips/tcg/translate.c
+++ b/target/mips/tcg/translate.c
@@ -17119,46 +17119,6 @@ void gen_intermediate_code(CPUState *cs, TranslationBlock *tb, int max_insns)
     translator_loop(&mips_tr_ops, &ctx.base, cs, tb, max_insns);
 }
 
-static void fpu_dump_state(CPUMIPSState *env, FILE * f, int flags)
-{
-    int i;
-    int is_fpu64 = !!(env->hflags & MIPS_HFLAG_F64);
-
-#define printfpr(fp)                                                    \
-    do {                                                                \
-        if (is_fpu64)                                                   \
-            qemu_fprintf(f, "w:%08x d:%016" PRIx64                      \
-                         " fd:%13g fs:%13g psu: %13g\n",                \
-                         (fp)->w[FP_ENDIAN_IDX], (fp)->d,               \
-                         (double)(fp)->fd,                              \
-                         (double)(fp)->fs[FP_ENDIAN_IDX],               \
-                         (double)(fp)->fs[!FP_ENDIAN_IDX]);             \
-        else {                                                          \
-            fpr_t tmp;                                                  \
-            tmp.w[FP_ENDIAN_IDX] = (fp)->w[FP_ENDIAN_IDX];              \
-            tmp.w[!FP_ENDIAN_IDX] = ((fp) + 1)->w[FP_ENDIAN_IDX];       \
-            qemu_fprintf(f, "w:%08x d:%016" PRIx64                      \
-                         " fd:%13g fs:%13g psu:%13g\n",                 \
-                         tmp.w[FP_ENDIAN_IDX], tmp.d,                   \
-                         (double)tmp.fd,                                \
-                         (double)tmp.fs[FP_ENDIAN_IDX],                 \
-                         (double)tmp.fs[!FP_ENDIAN_IDX]);               \
-        }                                                               \
-    } while (0)
-
-
-    qemu_fprintf(f,
-                 "CP1 FCR0 0x%08x  FCR31 0x%08x  SR.FR %d  fp_status 0x%02x\n",
-                 env->active_fpu.fcr0, env->active_fpu.fcr31, is_fpu64,
-                 get_float_exception_flags(&env->active_fpu.fp_status));
-    for (i = 0; i < 32; (is_fpu64) ? i++ : (i += 2)) {
-        qemu_fprintf(f, "%3s: ", fregnames[i]);
-        printfpr(&env->active_fpu.fpr[i]);
-    }
-
-#undef printfpr
-}
-
 void mips_tcg_init(void)
 {
     int i;

--- a/target/mips/tcg/translate.h
+++ b/target/mips/tcg/translate.h
@@ -129,9 +129,9 @@ enum {
     gen_helper_##name(cpu_env, arg1, arg2, tcg_constant_i32(arg3));\
     } while (0)
 
-void generate_exception(DisasContext *ctx, int excp);
-void generate_exception_err(DisasContext *ctx, int excp, int err);
-void generate_exception_end(DisasContext *ctx, int excp);
+void generate_exception(DisasContext *ctx, MipsExcp excp);
+void generate_exception_err(DisasContext *ctx, MipsExcp excp, int err);
+void generate_exception_end(DisasContext *ctx, MipsExcp excp);
 void gen_reserved_instruction(DisasContext *ctx);
 
 void check_insn(DisasContext *ctx, uint64_t flags);

--- a/target/mips/tcg/translate_cheri.c
+++ b/target/mips/tcg/translate_cheri.c
@@ -1219,6 +1219,8 @@ static void gen_cp2 (DisasContext *ctx, uint32_t opc, int r16, int r11, int r6)
         case OPC_CCSEAL_NI: /* 0x1f */
             check_cop2x(ctx);
             generate_ccseal(r16, r11, r6);
+            opn = "ccseal";
+            break;
         case OPC_CTESTSUBSET_NI: /* 0x20 */
             check_cop2x(ctx);
             generate_ctestsubset(ctx, r16, r11, r6);

--- a/target/riscv/cheri-archspecific-early.h
+++ b/target/riscv/cheri-archspecific-early.h
@@ -112,8 +112,6 @@ enum CheriSCR {
 /* TODO: switch tag clearing to true once CheriBSD is ready for it. */
 #define CHERI_TAG_CLEAR_ON_INVALID(env) (env_archcpu(env)->cfg.ext_cheri_v9)
 #define CHERI_NO_RELOCATION(env)            (env_archcpu(env)->cfg.ext_cheri_v9)
-#define CHERI_TRANSLATE_DDC_RELOCATION(ctx) (!(ctx)->cheri_v9_semantics)
-#define CHERI_TRANSLATE_PCC_RELOCATION(ctx) (!(ctx)->cheri_v9_semantics)
 #define CINVOKE_DATA_REGNUM 31
 
 static inline const cap_register_t *cheri_get_ddc(CPURISCVState *env) {

--- a/target/riscv/cheri-archspecific-translate.h
+++ b/target/riscv/cheri-archspecific-translate.h
@@ -1,0 +1,10 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2025 Alex Richardson
+ */
+
+#pragma once
+
+#define CHERI_TRANSLATE_DDC_RELOCATION(ctx) (!(ctx)->cheri_v9_semantics)
+#define CHERI_TRANSLATE_PCC_RELOCATION(ctx) (!(ctx)->cheri_v9_semantics)

--- a/target/riscv/cpu.h
+++ b/target/riscv/cpu.h
@@ -376,17 +376,6 @@ struct CPURISCVState {
     QEMUTimer *timer; /* Internal timer */
 };
 
-// Note: the pc does not have to be up-to-date, tb start is fine.
-// We may miss a few dumps or print too many if -dfilter is on but
-// that shouldn't really matter.
-static inline target_ulong cpu_get_recent_pc(CPURISCVState *env) {
-#ifdef TARGET_CHERI
-    return env->pcc._cr_cursor;
-#else
-    return env->pc;
-#endif
-}
-
 OBJECT_DECLARE_TYPE(RISCVCPU, RISCVCPUClass,
                     RISCV_CPU)
 
@@ -696,6 +685,20 @@ static inline bool pc_is_current(CPURISCVState *env)
     return env->_pc_is_current;
 #else
     return true;
+#endif
+}
+
+/*
+ * Note: the pc does not have to be up-to-date, tb start is fine.
+ * We may miss a few dumps or print too many if -dfilter is on but
+ * that shouldn't really matter.
+ */
+static inline target_ulong cpu_get_recent_pc(CPURISCVState *env)
+{
+#ifdef TARGET_CHERI
+    return env->pcc._cr_cursor;
+#else
+    return env->pc;
 #endif
 }
 

--- a/target/riscv/cpu.h
+++ b/target/riscv/cpu.h
@@ -376,15 +376,6 @@ struct CPURISCVState {
     QEMUTimer *timer; /* Internal timer */
 };
 
-static inline bool pc_is_current(CPURISCVState *env)
-{
-#ifdef CONFIG_DEBUG_TCG
-    return env->_pc_is_current;
-#else
-    return true;
-#endif
-}
-
 // Note: the pc does not have to be up-to-date, tb start is fine.
 // We may miss a few dumps or print too many if -dfilter is on but
 // that shouldn't really matter.
@@ -698,6 +689,15 @@ typedef CPURISCVState CPUArchState;
 typedef RISCVCPU ArchCPU;
 #include "exec/cpu-all.h"
 #include "cpu_cheri.h"
+
+static inline bool pc_is_current(CPURISCVState *env)
+{
+#ifdef CONFIG_DEBUG_TCG
+    return env->_pc_is_current;
+#else
+    return true;
+#endif
+}
 
 FIELD(TB_FLAGS, MEM_IDX, 0, 3)
 FIELD(TB_FLAGS, VL_EQ_VLMAX, 3, 1)

--- a/target/riscv/cpu_helper.c
+++ b/target/riscv/cpu_helper.c
@@ -823,7 +823,7 @@ restart:
 #if defined(TARGET_CHERI) && !defined(TARGET_RISCV32)
             case MMU_DATA_CAP_STORE:
                 updated_pte |= PTE_CD;
-                /* FALLTHROUGH */
+                QEMU_FALLTHROUGH;
 #endif
             case MMU_DATA_STORE:
                 updated_pte |= PTE_D;

--- a/target/riscv/insn_trans/trans_cheri.c.inc
+++ b/target/riscv/insn_trans/trans_cheri.c.inc
@@ -611,26 +611,14 @@ static inline bool do_trans_modesw(DisasContext *ctx, bool to_capmode)
     gen_helper_modesw(cpu_env, tcg_const_i32(to_capmode));
 
     /*
-     * There's a number of RISC-V instructions whose behaviour depends on the
-     * mode. For some of them, the mode is checked at translation time (not at
-     * execution time).
-     * -> We have to process the mode update before any further translations.
+     * The current execution mode is checked at translation time (not at
+     * execution time) and is part of the translation block flags, so these
+     * flags are no longer correct after executing modesw -> we have to process
+     * the mode update and exit the translation block.
      *
-     * This comes down to ending the current translation block (tb). The tb is
-     * then cached and executed. After that, the status is updated by
-     * cheri_cpu_get_tb_cpu_state before the next tb is translated.
-     *
-     * We were wondering if the tb cache would cause issues in a scenario
-     * such as
-     *    - tb with modesw is executed
-     *    - mode update
-     *    - next tb is to be translated - but it's already in the cache
-     *    - cached tb is executed - but it was translated based on
-     *      previous mode
-     *
-     * Note: The key for locating a cached tb in the hashtable includes the cpu
-     * status (part of which is the mode), so even if the next PC address has a
-     * cached TB, the lookup will not find the mismatched one.
+     * Note: Translating the same code with a different initial mode will never
+     * find a cached block with incorrect initial mode since the mode is part of
+     * the TB flags and they are used as part of the hash table lookup.
      *
      * TODO: it should be possible to update the flag in DisasContext and
      * continue translation after the modesw, but I am not confident this will

--- a/target/riscv/op_helper_cheri.c
+++ b/target/riscv/op_helper_cheri.c
@@ -192,7 +192,7 @@ void HELPER(cspecialrw)(CPUArchState *env, uint32_t cd, uint32_t cs,
             target_ulong new_tvec = SCR_TO_PROGRAM_COUNTER(env, &new_val);
             target_ulong new_mode = new_tvec & 3;
             /* The low two bits encode the mode, but only 0 and 1 are valid. */
-            if ((new_tvec & 3) > 1) {
+            if (new_mode > 1) {
                 /* Invalid mode, keep the old one. */
                 new_tvec &= ~(target_ulong)3;
                 new_tvec |= SCR_TO_PROGRAM_COUNTER(env, scr) & 3;

--- a/target/riscv/translate.c
+++ b/target/riscv/translate.c
@@ -233,17 +233,6 @@ static TCGv temp_new(DisasContext *ctx)
     return ctx->temp[ctx->ntemp++] = tcg_temp_new();
 }
 
-#ifdef CONFIG_RVFI_DII
-//#define gen_get_gpr(t, reg_num, field_prefix)                                  \
-//    do {                                                                       \
-//        _gen_get_gpr(t, reg_num);                                              \
-//        gen_rvfi_dii_set_field(field_prefix##_data, t);                        \
-//        gen_rvfi_dii_set_field_const(field_prefix##_addr, reg_num);            \
-//    } while (0)
-#else
-// #define gen_get_gpr(t, reg_num, field) _gen_get_gpr(t, reg_num)
-#endif
-
 static TCGv get_gpr(DisasContext *ctx, int reg_num, DisasExtend ext)
 {
     TCGv t;

--- a/tcg/tcg-op.c
+++ b/tcg/tcg-op.c
@@ -3013,7 +3013,7 @@ static void tcg_gen_qemu_st_i32_with_checked_addr_cond_invalidate(
     gen_rvfi_dii_set_mem_data_i32(w, addr, val, memop);
     plugin_gen_mem_callbacks(addr, oi, QEMU_PLUGIN_MEM_W);
 #if defined(TARGET_CHERI) || defined(CONFIG_TCG_LOG_INSTR)
-    TCGv_i32 tcoi = tcg_const_i32(oi);
+    TCGv_i32 tcoi = tcg_const_i32(make_memop_idx(memop, idx));
 #if defined(CONFIG_TCG_LOG_INSTR)
     if (tcg_ctx_logging_enabled) {
         gen_helper_qemu_log_instr_store32(cpu_env, addr, val, tcoi);

--- a/tests/docker/docker.py
+++ b/tests/docker/docker.py
@@ -186,7 +186,7 @@ def _check_binfmt_misc(executable):
               (binary))
         return None, True
 
-    m = re.search("interpreter (\S+)\n", entry)
+    m = re.search(r"interpreter (\S+)\n", entry)
     interp = m.group(1)
     if interp and interp != executable:
         print("binfmt_misc for %s does not point to %s, using %s" %

--- a/util/log.c
+++ b/util/log.c
@@ -75,7 +75,6 @@ static void qemu_logfile_free(QemuLogFile *logfile)
 
 static bool log_uses_own_buffers;
 
-__attribute__((weak)) int qemu_log_instr_global_switch(int log_flags);
 __attribute__((weak)) int qemu_log_instr_global_switch(int log_flags)
 {
     /* Real implementation in accel/tcg/log_instr.c. */


### PR DESCRIPTION
GCC warnings showed a few minor mismerges where we failed to remove declarations that got moved to other files. Also pulls in a few fixes from https://github.com/CHERI-Alliance/qemu

PR for CI