### PR TITLE
Remove check for Global permission on CJ(AL)R

### DIFF
--- a/target/cheri-common/op_helper_cheri_common.c
+++ b/target/cheri-common/op_helper_cheri_common.c
@@ -429,8 +429,6 @@ void cheri_jump_and_link_checked(CPUArchState *env, uint32_t link_reg,
         raise_cheri_exception(env, CapEx_SealViolation, target_reg);
     } else if (!cap_has_perms(target, CAP_PERM_EXECUTE)) {
         raise_cheri_exception(env, CapEx_PermitExecuteViolation, target_reg);
-    } else if (!cap_has_perms(target, CAP_PERM_GLOBAL)) {
-        raise_cheri_exception(env, CapEx_GlobalViolation, target_reg);
     } else if (!validate_jump_target(env, target, target_addr, target_reg,
                                      _host_return_address)) {
         assert(false && "Should have raised an exception");

--- a/target/mips/op_helper_cheri.c
+++ b/target/mips/op_helper_cheri.c
@@ -346,8 +346,6 @@ target_ulong CHERI_HELPER_IMPL(cjr(CPUArchState *env, uint32_t cb))
         raise_cheri_exception(env, CapEx_SealViolation, cb);
     } else if (!cap_has_perms(cbp, CAP_PERM_EXECUTE)) {
         raise_cheri_exception(env, CapEx_PermitExecuteViolation, cb);
-    } else if (!cap_has_perms(cbp, CAP_PERM_GLOBAL)) {
-        raise_cheri_exception(env, CapEx_GlobalViolation, cb);
     } else if (!cap_is_in_bounds(cbp, cap_get_cursor(cbp), 4)) {
         raise_cheri_exception(env, CapEx_LengthViolation, cb);
     } else if (align_of(4, cap_get_cursor(cbp))) {


### PR DESCRIPTION
The older CHERI ISA specifications for MIPS (prior to v6) included this check, but we failed to remove it from QEMU when the was changed in the spec. RISC-V never had this requirement, but everything worked fine since we never removed global from code capabilities.

Fixes: https://github.com/CTSRD-CHERI/qemu/issues/273