### PR TITLE
Fix build failure due to int-conversion

### DIFF
--- a/util/fdmon-io_uring.c
+++ b/util/fdmon-io_uring.c
@@ -179,7 +179,11 @@ static void add_poll_remove_sqe(AioContext *ctx, AioHandler *node)
 {
     struct io_uring_sqe *sqe = get_sqe(ctx);
 
+#ifdef LIBURING_HAVE_DATA64
+    io_uring_prep_poll_remove(sqe, (__u64)(uintptr_t)node);
+#else
     io_uring_prep_poll_remove(sqe, node);
+#endif
 }
 
 /* Add a timeout that self-cancels when another cqe becomes ready */

--- a/util/fdmon-io_uring.c
+++ b/util/fdmon-io_uring.c
@@ -180,7 +180,7 @@ static void add_poll_remove_sqe(AioContext *ctx, AioHandler *node)
     struct io_uring_sqe *sqe = get_sqe(ctx);
 
 #ifdef LIBURING_HAVE_DATA64
-    io_uring_prep_poll_remove(sqe, (__u64)(uintptr_t)node);
+    io_uring_prep_poll_remove(sqe, (uintptr_t)node);
 #else
     io_uring_prep_poll_remove(sqe, node);
 #endif


### PR DESCRIPTION
This fixes

```
FAILED: [code=1] libqemuutil.a.p/util_fdmon-io_uring.c.o 
/usr/bin/cc -Ilibqemuutil.a.p -I. -I../../qemu -Isubprojects/libvhost-user -I../../qemu/subprojects/libvhost-user -Iqapi -Itrace -Iui -Iui/shader -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/sysprof-6 -I/usr/lib64/libffi/include -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/gio-unix-2.0 -fdiagnostics-color=auto -pipe -Wall -Winvalid-pch -std=gnu99 -O2 -g -isystem /data-scratch/flo/cheri/qemu/linux-headers -isystem linux-headers -iquote . -iquote /data-scratch/flo/cheri/qemu -iquote /data-scratch/flo/cheri/qemu/include -iquote /data-scratch/flo/cheri/qemu/disas/libvixl -iquote /data-scratch/flo/cheri/qemu/tcg/i386 -iquote /data-scratch/flo/cheri/qemu/accel/tcg -pthread -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -m64 -mcx16 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Wstrict-prototypes -Wredundant-decls -Wundef -Wwrite-strings -Wmissing-prototypes -fno-strict-aliasing -fno-common -fwrapv -flto -O3 -Werror=implicit-function-declaration -Werror=incompatible-pointer-types -Werror=format -Werror=return-type -Wno-sign-compare -Wno-unused-parameter -Wno-missing-field-initializers -Wno-maybe-uninitialized -Wold-style-declaration -Wold-style-definition -Wtype-limits -Wformat-security -Wformat-y2k -Winit-self -Wignored-qualifiers -Wempty-body -Wnested-externs -Wendif-labels -Wexpansion-to-defined -Wimplicit-fallthrough=2 -Wno-missing-include-dirs -Wno-shift-negative-value -Wno-psabi -fPIC -MD -MQ libqemuutil.a.p/util_fdmon-io_uring.c.o -MF libqemuutil.a.p/util_fdmon-io_uring.c.o.d -o libqemuutil.a.p/util_fdmon-io_uring.c.o -c ../../qemu/util/fdmon-io_uring.c
../../qemu/util/fdmon-io_uring.c: In function ‘add_poll_remove_sqe’:
../../qemu/util/fdmon-io_uring.c:182:36: error: passing argument 2 of ‘io_uring_prep_poll_remove’ makes integer from pointer without a cast [-Wint-conversion]
  182 |     io_uring_prep_poll_remove(sqe, node);
      |                                    ^~~~
      |                                    |
      |                                    AioHandler *
In file included from /data-scratch/flo/cheri/qemu/include/block/aio.h:18,
                 from ../../qemu/util/aio-posix.h:20,
                 from ../../qemu/util/fdmon-io_uring.c:49:
/usr/include/liburing.h:659:52: note: expected ‘__u64’ {aka ‘long long unsigned int’} but argument is of type ‘AioHandler *’
  659 |                                              __u64 user_data)
      |                                              ~~~~~~^~~~~~~~~
```
by applying the relevant upstream patches.

See also https://github.com/CTSRD-CHERI/cheribuild/pull/421