### PR TITLE
Fix bug in BSD usermode which leads to memory overwriting

### DIFF
--- a/bsd-user/elfload.c
+++ b/bsd-user/elfload.c
@@ -976,9 +976,18 @@ int load_elf_binary(struct bsd_binprm *bprm, struct target_pt_regs *regs,
         break;
     }
 
+    /* XXXZY You don't want et_dyn_addr to be fixed if the target executable is big
+       otherwise load_elf_sections() may overwrite existing mappings */
     et_dyn_addr = 0;
-    if (elf_ex.e_type == ET_DYN && baddr == 0)
-        et_dyn_addr = ELF_ET_DYN_LOAD_ADDR;
+    if (elf_ex.e_type == ET_DYN) {
+        error = target_mmap(ELF_ET_DYN_LOAD_ADDR, ET_DYN_MAP_SIZE, PROT_NONE,
+            MAP_PRIVATE | MAP_ANON, -1, 0);
+        if (error == -1) {
+            perror("mmap");
+            exit(-1);
+        }
+        et_dyn_addr = TARGET_ELF_PAGESTART(error - baddr);
+    }
 
     /* Do this so that we can load the interpreter, if need be.  We will
        change some of these later */


### PR DESCRIPTION
`load_elf_sections()` mmaps at a fixed address indicated by `et_dyn_addr`. When emulating big executables, this becomes an issue because it tries to mmap memory regions that overlap with adjacent valid memory mappings due to the size. For example, qemu-morello is mapped at 0x200000; and then the emulated V8 mksnapshot is mapped from 0x0000000000100000 to 0x0000000001848000, overwriting the qemu-morello mapping.

Before `load_elf_sections()`:
```
gef>  vm
[ Legend:  Code | Heap | Stack ]
Start              End                Offset             Perm Path
0x0000000000200000 0x0000000000513000 0x0000000000000000 r-- /home/zyj20/cheri/output/bsd-user-sdk/bin/qemu-morello
0x0000000000513000 0x00000000009e9000 0x0000000000312000 r-x /home/zyj20/cheri/output/bsd-user-sdk/bin/qemu-morello
[...]
```

After:
```
gef>  vm
[ Legend:  Code | Heap | Stack ]
Start              End                Offset             Perm Path
0x0000000000100000 0x0000000001848000 0x0000000000000000 r-- /home/zyj20/v8-work/v8/out/cheri-uncompressed-cross/mksnapshot
0x0000000001848000 0x0000000001849000 0x0000000000000000 r--
[...]
```