### PR TITLE
morello: print capabilities in a CPU trace

### DIFF
--- a/target/arm/cpu.c
+++ b/target/arm/cpu.c
@@ -935,6 +935,46 @@ static void arm_disas_set_info(CPUState *cpu, disassemble_info *info)
 
 #ifdef TARGET_AARCH64
 
+#ifdef TARGET_CHERI
+static void aarch64_cpu_dump_cap_register(FILE *f, const char *capname,
+    const cap_register_t *capreg)
+{
+    uint32_t perms;
+
+    perms = cap_get_all_perms(capreg);
+
+    qemu_fprintf(f, " %8s  0x%016" PRIx64 "%016" PRIx64 "  0x%" PRIx64
+        " [%s%s%s%s%s%s,0x%" PRIx64 "-0x%" PRIx64 "]",
+        capname,
+        CAP_cc(compress_raw)(capreg) ^ CAP_MEM_XOR_MASK,
+        cap_get_cursor(capreg),
+        cap_get_cursor(capreg),
+        perms & CAP_PERM_LOAD ? "r" : "",
+        perms & CAP_PERM_STORE ? "w" : "",
+        perms & CAP_PERM_EXECUTE ? "x" : "",
+        perms & CAP_PERM_LOAD_CAP ? "R" : "",
+        perms & CAP_PERM_STORE_CAP ? "W" : "",
+        perms & CAP_PERM_EXECUTIVE ? "E" : "",
+        cap_get_base(capreg),
+        cap_get_top(capreg));
+    if (!capreg->cr_tag || !cap_is_unsealed(capreg)) {
+        qemu_fprintf(f, " (");
+        if (!capreg->cr_tag) {
+            qemu_fprintf(f, "invalid");
+            if (!cap_is_unsealed(capreg)) {
+                qemu_fprintf(f, ", ");
+            }
+        }
+        if (!cap_is_unsealed(capreg)) {
+            qemu_fprintf(f, "%s",
+                cap_is_sealed_entry(capreg) ?  "sentry" : "sealed");
+        }
+        qemu_fprintf(f, ")");
+    }
+    qemu_fprintf(f, "\n");
+}
+#endif
+
 static void aarch64_cpu_dump_state(CPUState *cs, FILE *f, int flags)
 {
     ARMCPU *cpu = ARM_CPU(cs);
@@ -944,6 +984,14 @@ static void aarch64_cpu_dump_state(CPUState *cs, FILE *f, int flags)
     int el = arm_current_el(env);
     const char *ns_status;
 
+#ifdef TARGET_CHERI
+    aarch64_cpu_dump_cap_register(f, "pcc", cheri_get_recent_pcc(env));
+    aarch64_cpu_dump_cap_register(f, "ddc", cheri_get_ddc(env));
+    for (i = 0; i < 32; i++) {
+        aarch64_cpu_dump_cap_register(f, cheri_gp_regnames[i],
+            get_readonly_capreg(env, i));
+    }
+#else
     qemu_fprintf(f, " PC=%016" PRIx64 " ", get_aarch_reg_as_x(&env->pc));
     for (i = 0; i < 32; i++) {
         target_ulong reg = arm_get_xreg(env, i);
@@ -954,13 +1002,19 @@ static void aarch64_cpu_dump_state(CPUState *cs, FILE *f, int flags)
                          (i + 2) % 3 ? " " : "\n");
         }
     }
+#endif
 
     if (arm_feature(env, ARM_FEATURE_EL3) && el != 3) {
         ns_status = env->cp15.scr_el3 & SCR_NS ? "NS " : "S ";
     } else {
         ns_status = "";
     }
-    qemu_fprintf(f, "PSTATE=%08x %c%c%c%c %sEL%d%c",
+#ifdef TARGET_CHERI
+    qemu_fprintf(f, " %8s  %08x %c%c%c%c %sEL%d%c\n",
+#else
+    qemu_fprintf(f, "%s=%08x %c%c%c%c %sEL%d%c",
+#endif
+                 "PSTATE",
                  psr,
                  psr & PSTATE_N ? 'N' : '-',
                  psr & PSTATE_Z ? 'Z' : '-',
@@ -971,7 +1025,13 @@ static void aarch64_cpu_dump_state(CPUState *cs, FILE *f, int flags)
                  psr & PSTATE_SP ? 'h' : 't');
 
     if (cpu_isar_feature(aa64_bti, cpu)) {
-        qemu_fprintf(f, "  BTYPE=%d", (psr & PSTATE_BTYPE) >> 10);
+#ifdef TARGET_CHERI
+        qemu_fprintf(f, " %8s  %d\n",
+#else
+        qemu_fprintf(f, "  %s=%d",
+#endif
+                     "BTYPE",
+                     (psr & PSTATE_BTYPE) >> 10);
     }
     if (!(flags & CPU_DUMP_FPU)) {
         qemu_fprintf(f, "\n");


### PR DESCRIPTION
Print capability registers in the same format as GDB does.

Example output:
```
      pcc  0xb09040003e77bc8effff00000365f214  0xffff00000365f214 [rxR,0xffff000003657910-0xffff00000365fce0]
      ddc  0xffffc000000100050000000000000000  0x0 [rwxRWE,0x0-0xffffffffffffffff]
       c0  0xdc1040006100a000ffffa000c00fa0a0  0xffffa000c00fa0a0 [rwRW,0xffffa000c00fa000-0xffffa000c00fa100]
       c1  0x9010400079b139a2ffff0000023839a2  0xffff0000023839a2 [rR,0xffff0000023839a2-0xffff0000023839b1]
       c2  0xdc1040003aff76faffff000003575e00  0xffff000003575e00 [rwRW,0xffff0000034edf00-0xffff000003575f00]
       c3  0xdc10400049f049b0ffff0000034049b0  0xffff0000034049b0 [rwRW,0xffff0000034049b0-0xffff0000034049f0]
       c4  0xdc1040006e286e27ffff000003216e27  0xffff000003216e27 [rwRW,0xffff000003216e27-0xffff000003216e28]
       c5  0xdc10400047000600ffffa000c0110600  0xffffa000c0110600 [rwRW,0xffffa000c0110600-0xffffa000c0110700]
       c6  0xdc1040006e286e27ffff000003216e27  0xffff000003216e27 [rwRW,0xffff000003216e27-0xffff000003216e28]
       c7  0xb090400010ee198effff00000235b37a  0xffff00000235b37a [rxR,0xffff000002331000-0xffff00000321d000]
       c8  0x00000000000000000000000000000006  0x6 [,0x0-0xffffffffffffffff] (invalid)
       c9  0x00000000000000000000000000000067  0x67 [,0x0-0xffffffffffffffff] (invalid)
      c10  0x00000000000000000000000000000000  0x0 [,0x0-0xffffffffffffffff] (invalid)
      c11  0x00000000000000000000000000000080  0x80 [,0x0-0xffffffffffffffff] (invalid)
      c12  0x00000000000000000000000000000070  0x70 [,0x0-0xffffffffffffffff] (invalid)
      c13  0x00000000000000000000000000000000  0x0 [,0x0-0xffffffffffffffff] (invalid)
      c14  0x00000000000000000000000100000000  0x100000000 [,0x0-0xffffffffffffffff] (invalid)
      c15  0x00000000000000000000000000000000  0x0 [,0x0-0xffffffffffffffff] (invalid)
      c16  0xb0904000be77bc8effff00000365f215  0xffff00000365f215 [rxR,0xffff000003657910-0xffff00000365fce0] (sentry)
      c17  0x00000000000000000000000000000000  0x0 [,0x0-0xffffffffffffffff] (invalid)
      c18  0xdc10400043008100ffff000002328100  0xffff000002328100 [rwRW,0xffff000002328100-0xffff000002328300]
      c19  0xdc1040004d400890ffff0000005d0890  0xffff0000005d0890 [rwRW,0xffff0000005d0890-0xffff0000005d0d40]
      c20  0x90104000672d66f4ffff0000024366f4  0xffff0000024366f4 [rR,0xffff0000024366f4-0xffff00000243672d]
      c21  0xdc10400049f049b0ffff0000034049b0  0xffff0000034049b0 [rwRW,0xffff0000034049b0-0xffff0000034049f0]
      c22  0xdc1040005ea0de70ffff00000309de70  0xffff00000309de70 [rwRW,0xffff00000309de70-0xffff00000309dea0]
      c23  0x9010400079b139a2ffff0000023839a2  0xffff0000023839a2 [rR,0xffff0000023839a2-0xffff0000023839b1]
      c24  0xdc1040004a1049f0ffff0000034049f0  0xffff0000034049f0 [rwRW,0xffff0000034049f0-0xffff000003404a10]
      c25  0xdc1040006100a000ffffa000c00fa000  0xffffa000c00fa000 [rwRW,0xffffa000c00fa000-0xffffa000c00fa100]
      c26  0x00000000000000000000000000000000  0x0 [,0x0-0xffffffffffffffff] (invalid)
      c27  0x90104000485ec857ffff00000245c857  0xffff00000245c857 [rR,0xffff00000245c857-0xffff00000245c85e]
      c28  0x90104000586f1861ffff0000023a1861  0xffff0000023a1861 [rR,0xffff0000023a1861-0xffff0000023a186f]
      c29  0xffffc0003007e007ffff0000005a2e00  0xffff0000005a2e00 [rwxRWE,0xffff00000059e000-0xffff0000005a3000]
      c30  0xbfffc000fc80fb90ffff00000087fc59  0xffff00000087fc59 [rxRWE,0xffff00000087fb90-0xffff00000087fc80] (sentry)
      csp  0xffffc00000073007ffff0000005a7ff0  0xffff0000005a7ff0 [rwxRWE,0xffff0000005a3000-0xffff0000005a8000]
   PSTATE  644000c5 -ZC- EL1h
```