### PR TITLE
RISC-V CSR diff reduction

### DIFF
--- a/target/riscv/cpu.h
+++ b/target/riscv/cpu.h
@@ -1062,7 +1062,6 @@ typedef struct {
     riscv_csr_op_fn op;
     riscv_csr_read128_fn read128;
     riscv_csr_write128_fn write128;
-    riscv_csr_log_update_fn log_update;
     /* The default priv spec version should be PRIV_VERSION_1_10_0 (i.e 0) */
     uint32_t min_priv_ver;
 } riscv_csr_operations;

--- a/target/riscv/csr.c
+++ b/target/riscv/csr.c
@@ -4006,7 +4006,7 @@ riscv_csr_operations csr_ops[CSR_TABLE_SIZE] = {
     [CSR_MTINST] =              CSR_OP_RW_PRIV(hmode, mtinst, 1_12_0),
 
 #ifdef TARGET_CHERI_RISCV_STD_093
-    [CSR_STVAL2]       = { "stval2", any, read_stval2, write_stval2 },
+    [CSR_STVAL2]       = { "stval2", smode, read_stval2, write_stval2 },
     [CSR_STVAL2]       = { "vstval2", hmode, read_vstval2, write_vstval2 },
 #endif
 

--- a/target/riscv/csr.c
+++ b/target/riscv/csr.c
@@ -2794,13 +2794,6 @@ static RISCVException write_pmpcfg(CPURISCVState *env, int csrno,
         return RISCV_EXCP_ILLEGAL_INST;
     }
     pmpcfg_csr_write(env, csrno - CSR_PMPCFG0, val);
-#ifdef CONFIG_TCG_LOG_INSTR
-    if (qemu_log_instr_enabled(env)) {
-        char buf[16];
-        snprintf(buf, sizeof(buf), "pmpcfg%d", csrno - CSR_PMPCFG0);
-        qemu_log_instr_reg(env, buf, val, csrno, LRI_CSR_ACCESS);
-    }
-#endif
     return RISCV_EXCP_NONE;
 }
 
@@ -2815,13 +2808,6 @@ static RISCVException write_pmpaddr(CPURISCVState *env, int csrno,
                                     target_ulong val)
 {
     pmpaddr_csr_write(env, csrno - CSR_PMPADDR0, val);
-#ifdef CONFIG_TCG_LOG_INSTR
-    if (qemu_log_instr_enabled(env)) {
-        char buf[16];
-        snprintf(buf, sizeof(buf), "pmpaddr%d", csrno - CSR_PMPADDR0);
-        qemu_log_instr_reg(env, buf, val, csrno, LRI_CSR_ACCESS);
-    }
-#endif
     return RISCV_EXCP_NONE;
 }
 

--- a/target/riscv/csr.c
+++ b/target/riscv/csr.c
@@ -3678,7 +3678,7 @@ static RISCVException riscv_csrrw_do64(CPURISCVState *env, int csrno,
     if (csr_ops[csrno].op) {
         ret = csr_ops[csrno].op(env, csrno, ret_value, new_value, write_mask);
 #ifdef CONFIG_TCG_LOG_INSTR
-        if (ret >= 0 && csr_ops[csrno].log_update) {
+        if (ret == RISCV_EXCP_NONE && csr_ops[csrno].log_update) {
             csr_ops[csrno].log_update(env, csrno, new_value);
         }
 #endif


### PR DESCRIPTION
Now that all CSR entries have a name we no longer need the custom logging function and can sync the code with upstream.