### PR TITLE
target/riscv: Fix stval2 reporting on CHERI PTE faults.

### DIFF
--- a/target/riscv/cpu_helper.c
+++ b/target/riscv/cpu_helper.c
@@ -1980,6 +1980,11 @@ void riscv_cpu_do_interrupt(CPUState *cs)
         if (cause == RISCV_EXCP_CHERI) {
             env->stval2 = cheri_exc_info;
             riscv_log_instr_csr_changed(env, CSR_STVAL2);
+        } else if (cause == RISCV_EXCP_LOAD_PAGE_FAULT ||
+                   cause == RISCV_EXCP_STORE_PAGE_FAULT) {
+            /* 0.9.3 reports 0/1/2 in mtval2 to report CHERI page faults */
+            assert(env->last_cap_cause == 0 || env->last_cap_cause == 1);
+            env->stval2 = env->last_cap_cause;
         }
 #endif
 


### PR DESCRIPTION
This is correctly implemented for mtval2 updates, but not for stval2.